### PR TITLE
Improve output of bitwise operations

### DIFF
--- a/src/org/jetbrains/java/decompiler/util/IntHelper.java
+++ b/src/org/jetbrains/java/decompiler/util/IntHelper.java
@@ -29,8 +29,10 @@ public final class IntHelper {
    */
   public static String adjustedIntRepresentation(int value) {
     // Check against the special int values to see if we're one of those, and return
-    if (SPECIAL_VALUES.containsKey(value)) {
-      return SPECIAL_VALUES.get(value);
+    String specialValue = SPECIAL_VALUES.get(value);
+
+    if (specialValue != null) {
+      return specialValue;
     }
 
     // Return the standard representation if we're not one of those

--- a/src/org/jetbrains/java/decompiler/util/IntHelper.java
+++ b/src/org/jetbrains/java/decompiler/util/IntHelper.java
@@ -1,0 +1,39 @@
+package org.jetbrains.java.decompiler.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A couple of helper methods with integers.
+ *
+ * @author SuperCoder79
+ */
+public final class IntHelper {
+  // Special values for adjusting the string representation of ints.
+  private static final Map<Integer, String> SPECIAL_VALUES = new HashMap<>();
+  static {
+    // Add color masking constants
+    SPECIAL_VALUES.put(0xFF, "0xFF");
+    SPECIAL_VALUES.put(0xFF00, "0xFF00");
+    SPECIAL_VALUES.put(0xFF0000, "0xFF0000");
+    SPECIAL_VALUES.put(0xFF000000, "0xFF000000");
+  }
+
+  private IntHelper() {}
+
+  /**
+   * Adjusts the string representation of an int to make it easier to read in certain cases, such as values used
+   * to mask components of an RGB color.
+   * @param value the input number
+   * @return The adjusted string
+   */
+  public static String adjustedIntRepresentation(int value) {
+    // Check against the special int values to see if we're one of those, and return
+    if (SPECIAL_VALUES.containsKey(value)) {
+      return SPECIAL_VALUES.get(value);
+    }
+
+    // Return the standard representation if we're not one of those
+    return String.valueOf(value);
+  }
+}


### PR DESCRIPTION
This PR improves two pain points with FernFlower's bitwise operation code, specifically:
* `& 65535` and `& 0xFFFF` being decompiled as `& '\uffff'`
* Hex values used in color bit masking such as `0xFF0000`, `0xFF00`, and `0xFF` not being decompiled properly

These issues have been addressed with this PR.