### PR TITLE
Fix boolean values assigned to int variables

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
@@ -132,6 +132,13 @@ public class AssignmentExprent extends Exprent {
 
     TextBuffer res = right.toJava(indent, tracer);
 
+    // This is an incredibly hacky fix for booleans being assigned to integer values.
+    // Certain cases will cause decompiled code to output "int i = true;` for nonzero constant values and this is a highly naive way to fix it.
+    // We check if the buffer containing the variable name starts with "int " and then re-resolve the textbuffer with the int representation instead.
+    if (this.right.type == EXPRENT_CONST && buffer.toString().startsWith("int ")) {
+      res = new TextBuffer(String.valueOf((int)((ConstExprent)this.right).getValue()));
+    }
+
     if (condType == CONDITION_NONE &&
         !leftType.isSuperset(rightType) &&
         (rightType.equals(VarType.VARTYPE_OBJECT) || leftType.type != CodeConstants.TYPE_OBJECT)) {


### PR DESCRIPTION
This PR fixes a longstanding issue where fernflower would assign boolean values to integer values. It also fixes it in the worst way possible. Sometimes, fernflower would produce a result of `int i = true;` for any nonzero values of i, causing much confusion for new modders. Fixing this will improve the experience of new modders looking at minecraft's code.