### PR TITLE
Remove parentheses from single-param lambdas

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -97,7 +97,11 @@ public class ClassWriter {
         MethodDescriptor md_lambda = MethodDescriptor.parseDescriptor(node.lambdaInformation.method_descriptor);
 
         if (!lambdaToAnonymous) {
-          buffer.append('(');
+          boolean lambdaParametersNeedParentheses = md_lambda.params.length != 1;
+
+          if (lambdaParametersNeedParentheses) {
+            buffer.append('(');
+          }
 
           boolean firstParameter = true;
           int index = node.lambdaInformation.is_content_method_static ? 0 : 1;
@@ -118,7 +122,10 @@ public class ClassWriter {
             index += md_content.params[i].stackSize;
           }
 
-          buffer.append(") ->");
+          if (lambdaParametersNeedParentheses) {
+            buffer.append(")");
+          }
+          buffer.append(" ->");
         }
 
         buffer.append(" {").appendLineSeparator();

--- a/testData/results/TestClassLambda.dec
+++ b/testData/results/TestClassLambda.dec
@@ -14,7 +14,7 @@ public class TestClassLambda {
    public void testLambda() {
       List var1 = Arrays.asList(1, 2, 3, 4, 5, 6, 7);// 29
       int var2 = (int)Math.random();// 30
-      var1.forEach((var2x) -> {// 32
+      var1.forEach(var2x -> {// 32
          int var3 = 2 * var2x;// 33
          System.out.println(var3 + var2 + this.field);// 34
       });// 35
@@ -53,7 +53,7 @@ public class TestClassLambda {
       ArrayList var1 = new ArrayList();// 62
       int var2 = var1.size() * 2;// 63
       int var3 = var1.size() * 5;// 64
-      var1.removeIf((var2x) -> {// 65
+      var1.removeIf(var2x -> {// 65
          return var2 >= var2x.length() && var2x.length() <= var3;
       });
    }// 66

--- a/testData/results/TestLambdaParams.dec
+++ b/testData/results/TestLambdaParams.dec
@@ -5,13 +5,13 @@ import java.util.function.Function;
 public class TestLambdaParams {
    public static void toCollection(Object var0) {
       Object var1 = null;// 23
-      Function var2 = (var1x) -> {
+      Function var2 = var1x -> {
          return var0;
       };// 24
-      Function var3 = (var1x) -> {
+      Function var3 = var1x -> {
          return var1;
       };// 25
-      Function var4 = (var0x) -> {
+      Function var4 = var0x -> {
          return var0x;
       };// 26
    }// 27


### PR DESCRIPTION
Removes the parentheses from lambdas with only 1 parameter, making them cleaner. Thank you so much for this @williambl!