### PR TITLE
Improved handling of multiple methods using the same name and descriptor

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
+++ b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
@@ -181,6 +181,10 @@ public class ClassWrapper {
     return methods.getWithKey(InterpreterUtil.makeUniqueKey(name, descriptor));
   }
 
+  public MethodWrapper getMethodWrapper(int index) {
+    return methods.get(index);
+  }
+
   public StructClass getClassStruct() {
     return classStruct;
   }

--- a/src/org/jetbrains/java/decompiler/struct/StructClass.java
+++ b/src/org/jetbrains/java/decompiler/struct/StructClass.java
@@ -3,6 +3,7 @@ package org.jetbrains.java.decompiler.struct;
 
 import org.jetbrains.java.decompiler.code.CodeConstants;
 import org.jetbrains.java.decompiler.main.DecompilerContext;
+import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
 import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
 import org.jetbrains.java.decompiler.struct.attr.StructGeneralAttribute;
 import org.jetbrains.java.decompiler.struct.attr.StructGenericSignatureAttribute;
@@ -82,7 +83,12 @@ public class StructClass extends StructMember {
     VBStyleCollection<StructMethod, String>methods = new VBStyleCollection<>(length);
     for (int i = 0; i < length; i++) {
       StructMethod method = StructMethod.create(in, pool, qualifiedName, bytecodeVersion, own);
-      methods.addWithKey(method, InterpreterUtil.makeUniqueKey(method.getName(), method.getDescriptor()));
+      String key = InterpreterUtil.makeUniqueKey(method.getName(), method.getDescriptor());
+      if (methods.containsKey(key)) {
+        String fullName = qualifiedName + "." + method.getName() + method.getDescriptor();
+        DecompilerContext.getLogger().writeMessage("Duplicate method " + fullName, IFernflowerLogger.Severity.WARN);
+      }
+      methods.addWithKey(method, key);
     }
 
     Map<String, StructGeneralAttribute> attributes = readAttributes(in, pool);

--- a/src/org/jetbrains/java/decompiler/struct/StructClass.java
+++ b/src/org/jetbrains/java/decompiler/struct/StructClass.java
@@ -233,10 +233,6 @@ public class StructClass extends StructMember {
     return own;
   }
 
-  public LazyLoader getLoader() {
-    return loader;
-  }
-
   public boolean isVersion5() {
     return (majorVersion > CodeConstants.BYTECODE_JAVA_LE_4 ||
             (majorVersion == CodeConstants.BYTECODE_JAVA_LE_4 && minorVersion > 0)); // FIXME: check second condition

--- a/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java
+++ b/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java
@@ -105,50 +105,6 @@ public class ConstantPool implements NewClassNameBuilder {
     interceptor = DecompilerContext.getPoolInterceptor();
   }
 
-  public static void skipPool(DataInputFullStream in) throws IOException {
-    int size = in.readUnsignedShort();
-
-    for (int i = 1; i < size; i++) {
-      byte tag = (byte)in.readUnsignedByte();
-      switch (tag) {
-        case CodeConstants.CONSTANT_Utf8:
-          in.readUTF();
-          break;
-
-        case CodeConstants.CONSTANT_Integer:
-        case CodeConstants.CONSTANT_Float:
-        case CodeConstants.CONSTANT_Fieldref:
-        case CodeConstants.CONSTANT_Methodref:
-        case CodeConstants.CONSTANT_InterfaceMethodref:
-        case CodeConstants.CONSTANT_NameAndType:
-        case CodeConstants.CONSTANT_InvokeDynamic:
-          in.discard(4);
-          break;
-
-        case CodeConstants.CONSTANT_Long:
-        case CodeConstants.CONSTANT_Double:
-          in.discard(8);
-          i++;
-          break;
-
-        case CodeConstants.CONSTANT_Class:
-        case CodeConstants.CONSTANT_String:
-        case CodeConstants.CONSTANT_MethodType:
-        case CodeConstants.CONSTANT_Module:
-        case CodeConstants.CONSTANT_Package:
-          in.discard(2);
-          break;
-
-        case CodeConstants.CONSTANT_MethodHandle:
-          in.discard(3);
-          break;
-
-        default:
-            throw new RuntimeException("Invalid Constant Pool entry #" + i + " Type: " + tag);
-      }
-    }
-  }
-
   public String[] getClassElement(int elementType, String className, int nameIndex, int descriptorIndex) {
     String elementName = ((PrimitiveConstant)getConstant(nameIndex)).getString();
     String descriptor = ((PrimitiveConstant)getConstant(descriptorIndex)).getString();

--- a/src/org/jetbrains/java/decompiler/struct/lazy/LazyLoader.java
+++ b/src/org/jetbrains/java/decompiler/struct/lazy/LazyLoader.java
@@ -2,9 +2,6 @@
 package org.jetbrains.java.decompiler.struct.lazy;
 
 import org.jetbrains.java.decompiler.main.extern.IBytecodeProvider;
-import org.jetbrains.java.decompiler.struct.StructClass;
-import org.jetbrains.java.decompiler.struct.StructMethod;
-import org.jetbrains.java.decompiler.struct.attr.StructGeneralAttribute;
 import org.jetbrains.java.decompiler.struct.consts.ConstantPool;
 import org.jetbrains.java.decompiler.util.DataInputFullStream;
 
@@ -46,72 +43,6 @@ public class LazyLoader {
     }
   }
 
-  public byte[] loadBytecode(StructClass classStruct, StructMethod mt, int codeFullLength) {
-    String className = classStruct.qualifiedName;
-
-    try (DataInputFullStream in = getClassStream(className)) {
-      if (in != null) {
-        in.discard(8);
-
-        ConstantPool pool = classStruct.getPool();
-        if (pool == null) {
-          pool = new ConstantPool(in);
-        }
-        else {
-          ConstantPool.skipPool(in);
-        }
-
-        in.discard(6);
-
-        // interfaces
-        in.discard(in.readUnsignedShort() * 2);
-
-        // fields
-        int size = in.readUnsignedShort();
-        for (int i = 0; i < size; i++) {
-          in.discard(6);
-          skipAttributes(in);
-        }
-
-        // methods
-        size = in.readUnsignedShort();
-        for (int i = 0; i < size; i++) {
-          in.discard(2);
-
-          int nameIndex = in.readUnsignedShort();
-          int descriptorIndex = in.readUnsignedShort();
-
-          String[] values = pool.getClassElement(ConstantPool.METHOD, className, nameIndex, descriptorIndex);
-          if (!mt.getName().equals(values[0]) || !mt.getDescriptor().equals(values[1])) {
-            skipAttributes(in);
-            continue;
-          }
-
-          int attrSize = in.readUnsignedShort();
-          for (int j = 0; j < attrSize; j++) {
-            int attrNameIndex = in.readUnsignedShort();
-            String attrName = pool.getPrimitiveConstant(attrNameIndex).getString();
-            if (!StructGeneralAttribute.ATTRIBUTE_CODE.name.equals(attrName)) {
-              in.discard(in.readInt());
-              continue;
-            }
-
-            in.discard(12);
-
-            return in.read(codeFullLength);
-          }
-
-          break;
-        }
-      }
-
-      return null;
-    }
-    catch (IOException ex) {
-      throw new RuntimeException(ex);
-    }
-  }
-
   public DataInputFullStream getClassStream(String externalPath, String internalPath) throws IOException {
     byte[] bytes = provider.getBytecode(externalPath, internalPath);
     return new DataInputFullStream(bytes);
@@ -120,14 +51,6 @@ public class LazyLoader {
   public DataInputFullStream getClassStream(String qualifiedClassName) throws IOException {
     Link link = mapClassLinks.get(qualifiedClassName);
     return link == null ? null : link.data != null ? new DataInputFullStream(link.data) : getClassStream(link.externalPath, link.internalPath);
-  }
-
-  public static void skipAttributes(DataInputFullStream in) throws IOException {
-    int length = in.readUnsignedShort();
-    for (int i = 0; i < length; i++) {
-      in.discard(2);
-      in.discard(in.readInt());
-    }
   }
 
   public static class Link {


### PR DESCRIPTION
Instead of discarding the bytecode and exception handler data this saves it in the `StructCodeAttribute` so it doesn't have to get parsed from the class again.

This prevents a crash where the wrong bytecode is used in case of duplicate methods.
Might also have some performance improvements by not having to parse the whole class again just to get the bytecode.

Both versions of the method will show up in the output and a warning is logged.