### PR TITLE
Fix VBStyleCollection::removeWithKey for elements that are not present

### DIFF
--- a/src/org/jetbrains/java/decompiler/util/VBStyleCollection.java
+++ b/src/org/jetbrains/java/decompiler/util/VBStyleCollection.java
@@ -85,7 +85,11 @@ public class VBStyleCollection<E, K> extends ArrayList<E> {
   }
 
   public void removeWithKey(K key) {
-    int index = map.get(key);
+    Integer indexBox = map.get(key);
+    if (indexBox == null) {
+      return;
+    }
+    int index = indexBox;
     addToListIndex(index + 1, -1);
     super.remove(index);
     lstKeys.remove(index);

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -126,7 +126,6 @@ public class SingleClassesTest extends SingleClassesTestBase {
   @Test public void testTryWithResources() { doTest("pkg/TestTryWithResources"); }
   // TODO: The (double) in front of the (int) should be removed
   @Test public void testMultiCast() { doTest("pkg/TestMultiCast"); }
-  // TODO: Fails to decompile
   @Test public void testNestedLoops() { doTest("pkg/TestNestedLoops"); }
   // TODO: The ternary here needs to be removed
   @Test public void testNestedLambdas() { doTest("pkg/TestNestedLambdas"); }

--- a/testData/results/TestNestedLoops.dec
+++ b/testData/results/TestNestedLoops.dec
@@ -1,8 +1,97 @@
 package pkg;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class TestNestedLoops {
    public void test() {
-      // $FF: Couldn't be decompiled
+      List<String> list = new ArrayList<>();// 8
+      int i = 0;// 9
+
+      while(true) {
+         while(i >= 10) {// 11
+         }
+
+         for(String s : list) {// 12
+            for(int j = 0; j < 20; ++j) {// 13
+               do {
+                  s.substring(j);// 15
+               } while(s.length() < j);// 16
+            }
+         }
+
+         ++i;// 19
+      }
    }
 }
 
+class 'pkg/TestNestedLoops' {
+   method 'test ()V' {
+      7      7
+      8      8
+      9      8
+      a      11
+      b      11
+      c      11
+      d      11
+      10      14
+      11      14
+      12      14
+      13      14
+      14      14
+      15      14
+      16      14
+      20      14
+      21      14
+      22      14
+      23      14
+      24      14
+      25      14
+      26      14
+      27      14
+      28      14
+      29      14
+      2a      14
+      2b      15
+      2c      15
+      2d      15
+      2e      15
+      2f      15
+      30      15
+      31      15
+      32      15
+      35      17
+      36      17
+      37      17
+      38      17
+      39      17
+      3a      17
+      3b      17
+      3d      18
+      3e      18
+      3f      18
+      40      18
+      41      18
+      42      18
+      43      18
+      44      18
+      47      15
+      48      15
+      49      15
+      50      22
+      51      22
+      52      22
+   }
+}
+
+Lines mapping:
+8 <-> 8
+9 <-> 9
+11 <-> 12
+12 <-> 15
+13 <-> 16
+15 <-> 18
+16 <-> 19
+19 <-> 23
+Not mapped:
+18


### PR DESCRIPTION
This caused a NullPointerException during decompilation of TestNestedLoops, which is now decompiled semi-reasonably