### PR TITLE
Some performance improvements

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
@@ -90,8 +90,8 @@ public class ClassesProcessor implements CodeConstants {
     boolean verifyAnonymousClasses = DecompilerContext.getOption(IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES);
 
     // create class nodes
-    for (StructClass cl : context.getClasses().values()) {
-      if (cl.isOwn() && !mapRootClasses.containsKey(cl.qualifiedName)) {
+    for (StructClass cl : context.getOwnClasses().values()) {
+      if (!mapRootClasses.containsKey(cl.qualifiedName)) {
         if (bDecompileInner) {
           StructInnerClassesAttribute inner = cl.getAttribute(StructGeneralAttribute.ATTRIBUTE_INNER_CLASSES);
 
@@ -152,7 +152,7 @@ public class ClassesProcessor implements CodeConstants {
                 continue;  // not a real inner class
               }
 
-              StructClass enclosingClass = context.getClasses().get(enclClassName);
+              StructClass enclosingClass = context.getClass(enclClassName);
               if (enclosingClass != null && enclosingClass.isOwn()) { // own classes only
                 Inner existingRec = mapInnerClasses.get(innerName);
                 if (existingRec == null) {

--- a/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
+++ b/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
@@ -37,7 +37,7 @@ public class ImportCollector {
       currentPackagePoint = "";
     }
 
-    Map<String, StructClass> classes = DecompilerContext.getStructContext().getClasses();
+    StructContext ctx = DecompilerContext.getStructContext();
     StructClass currentClass = root.classStruct;
     while (currentClass != null) {
       // all field names for the current class ..
@@ -46,7 +46,7 @@ public class ImportCollector {
       }
 
       // .. and traverse through parent.
-      currentClass = currentClass.superClass != null ? classes.get(currentClass.superClass.getString()) : null;
+      currentClass = currentClass.superClass != null ? ctx.getClass(currentClass.superClass.getString()) : null;
     }
 
     collectConflictingShortNames(root, new HashMap<>());
@@ -191,7 +191,7 @@ public class ImportCollector {
   }
 
   private void getSuperClassInnerClasses(ClassNode node, Map<String, String> names) {
-    Map<String, StructClass> classes = DecompilerContext.getStructContext().getClasses();
+    StructContext ctx = DecompilerContext.getStructContext();
     LinkedList<String> queue = new LinkedList<>();
     StructClass currentClass = node.classStruct;
     while (currentClass != null) {
@@ -212,9 +212,9 @@ public class ImportCollector {
       }
 
       // .. and traverse through parent.
-      currentClass = !queue.isEmpty() ? classes.get(queue.removeFirst()) : null;
+      currentClass = !queue.isEmpty() ? ctx.getClass(queue.removeFirst()) : null;
       while (currentClass == null && !queue.isEmpty()) {
-        currentClass = classes.get(queue.removeFirst());
+        currentClass = ctx.getClass(queue.removeFirst());
       }
     }
   }

--- a/src/org/jetbrains/java/decompiler/modules/renamer/IdentifierConverter.java
+++ b/src/org/jetbrains/java/decompiler/modules/renamer/IdentifierConverter.java
@@ -155,7 +155,7 @@ public class IdentifierConverter implements NewClassNameBuilder {
         String classname = helper.getNextClassName(classOldFullName, ConverterHelper.getSimpleClassName(classOldFullName));
         classNewFullName = ConverterHelper.replaceSimpleClassName(classOldFullName, classname);
       }
-      while (context.getClasses().containsKey(classNewFullName));
+      while (context.hasClass(classNewFullName));
 
       interceptor.addName(classOldFullName, classNewFullName);
     }
@@ -295,16 +295,12 @@ public class IdentifierConverter implements NewClassNameBuilder {
 
   private void buildInheritanceTree() {
     Map<String, ClassWrapperNode> nodes = new HashMap<>();
-    Map<String, StructClass> classes = context.getClasses();
+    Map<String, StructClass> classes = context.getOwnClasses();
 
     List<ClassWrapperNode> rootClasses = new ArrayList<>();
     List<ClassWrapperNode> rootInterfaces = new ArrayList<>();
 
     for (StructClass cl : classes.values()) {
-      if (!cl.isOwn()) {
-        continue;
-      }
-
       LinkedList<StructClass> stack = new LinkedList<>();
       LinkedList<ClassWrapperNode> stackSubNodes = new LinkedList<>();
 

--- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
+++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
@@ -8,26 +8,26 @@ import org.jetbrains.java.decompiler.struct.gen.generics.GenericMain;
 import org.jetbrains.java.decompiler.struct.gen.generics.GenericMethodDescriptor;
 import org.jetbrains.java.decompiler.struct.lazy.LazyLoader;
 import org.jetbrains.java.decompiler.util.DataInputFullStream;
-import org.jetbrains.java.decompiler.util.InterpreterUtil;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.jar.JarFile;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.jar.Manifest;
 
 public class StructContext {
   private final IResultSaver saver;
   private final IDecompiledData decompiledData;
   private final LazyLoader loader;
   private final Map<String, ContextUnit> units = new HashMap<>();
-  private final Map<String, StructClass> classes = new HashMap<>();
+  private final Map<String, ClassProvider> classes = new HashMap<>();
+  private final Map<String, StructClass> ownClasses = new HashMap<>();
   private final Map<String, List<String>> abstractNames = new HashMap<>();
+  private final Map<File, FileSystem> zipFiles = new HashMap<>();
 
   public StructContext(IResultSaver saver, IDecompiledData decompiledData, LazyLoader loader) {
     this.saver = saver;
@@ -39,11 +39,16 @@ public class StructContext {
   }
 
   public StructClass getClass(String name) {
-    return classes.get(name);
+    ClassProvider provider = classes.get(name);
+    if (provider == null) {
+      return null;
+    }
+    return provider.get();
   }
 
   public void reloadContext() throws IOException {
-    for (ContextUnit unit : units.values()) {
+    for (Map.Entry<String, ContextUnit> e : units.entrySet()) {
+      ContextUnit unit = e.getValue();
       for (StructClass cl : unit.getClasses()) {
         classes.remove(cl.qualifiedName);
       }
@@ -52,7 +57,7 @@ public class StructContext {
 
       // adjust global class collection
       for (StructClass cl : unit.getClasses()) {
-        classes.put(cl.qualifiedName, cl);
+        classes.put(cl.qualifiedName, new ClassProvider(cl));
       }
     }
   }
@@ -111,17 +116,7 @@ public class StructContext {
       }
 
       if (filename.endsWith(".class")) {
-        try (DataInputFullStream in = loader.getClassStream(file.getAbsolutePath(), null)) {
-          StructClass cl = StructClass.create(in, isOwn, loader);
-          classes.put(cl.qualifiedName, cl);
-          unit.addClass(cl, filename);
-          loader.addClassLink(cl.qualifiedName, new LazyLoader.Link(file.getAbsolutePath(), null));
-        }
-        catch (IOException ex) {
-          String message = "Corrupted class file: " + file;
-          DecompilerContext.getLogger().writeMessage(message, ex);
-          throw new RuntimeException(ex);
-        }
+        addClass(unit, null, path, filename, isOwn, () -> loader.getClassBytes(file.getAbsolutePath(), null));
       }
       else {
         unit.addOtherEntry(file.getAbsolutePath(), filename);
@@ -129,58 +124,85 @@ public class StructContext {
     }
   }
 
-  private void addArchive(String path, File file, int type, boolean isOwn) throws IOException {
-    DecompilerContext.getLogger().writeMessage("Adding Archive: " + file.getAbsolutePath(), Severity.INFO);
-    try (ZipFile archive = type == ContextUnit.TYPE_JAR ? new JarFile(file) : new ZipFile(file)) {
-      Enumeration<? extends ZipEntry> entries = archive.entries();
-      while (entries.hasMoreElements()) {
-        ZipEntry entry = entries.nextElement();
-
-        ContextUnit unit = units.get(path + "/" + file.getName());
-        if (unit == null) {
-          unit = new ContextUnit(type, path, file.getName(), isOwn, saver, decompiledData);
-          if (type == ContextUnit.TYPE_JAR) {
-            unit.setManifest(((JarFile)archive).getManifest());
-          }
-          units.put(path + "/" + file.getName(), unit);
+  private FileSystem getZipFileSystem(File file) throws IOException {
+    try {
+      return zipFiles.computeIfAbsent(file, f -> {
+        URI uri = null;
+        try {
+          uri = new URI("jar:file", null, f.toURI().getPath(), null);
+          return FileSystems.newFileSystem(uri, Collections.emptyMap());
+        } catch (FileSystemAlreadyExistsException e) {
+          return FileSystems.getFileSystem(uri);
+        } catch (URISyntaxException e) {
+          throw new RuntimeException(e);
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
         }
-
-        String name = entry.getName();
-        if (!entry.isDirectory()) {
-          if (name.endsWith(".class")) {
-            byte[] bytes = InterpreterUtil.getBytes(archive, entry);
-            DecompilerContext.getLogger().writeMessage("  Loading Class: " + name, Severity.INFO);
-            StructClass cl = StructClass.create(new DataInputFullStream(bytes), isOwn, loader);
-            classes.put(cl.qualifiedName, cl);
-            unit.addClass(cl, name);
-            loader.addClassLink(cl.qualifiedName, new LazyLoader.Link(file.getAbsolutePath(), name));
-          }
-          else {
-            unit.addOtherEntry(file.getAbsolutePath(), name);
-          }
-        }
-        else {
-          unit.addDirEntry(name);
-        }
-      }
+      });
+    } catch (UncheckedIOException e) {
+      throw e.getCause();
     }
   }
 
-  public void addData(String path, String cls, byte[] data, boolean isOwn) throws IOException {
-        ContextUnit unit = units.get(path);
-        if (unit == null) {
-          unit = new ContextUnit(ContextUnit.TYPE_FOLDER, path, cls, isOwn, saver, decompiledData);
-          units.put(path, unit);
+  private void addArchive(String externalPath, File file, int type, boolean isOwn) throws IOException {
+    DecompilerContext.getLogger().writeMessage("Adding Archive: " + file.getAbsolutePath(), Severity.INFO);
+    FileSystem fs = getZipFileSystem(file);
+    ContextUnit unit = units.computeIfAbsent(externalPath + "/" + file.getName(), k -> new ContextUnit(type, externalPath, file.getName(), isOwn, saver, decompiledData));
+    Files.walkFileTree(fs.getPath("/"), new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
+        String name = path.toString().substring(1);
+        if (name.endsWith(".class")) {
+          addClass(unit, name.substring(0, name.length() - 6), file.getAbsolutePath(), path.toString(), isOwn, path);
+        } else {
+          if ("META-INF/MANIFEST.MF".equals(name)) {
+            unit.setManifest(new Manifest(Files.newInputStream(path)));
+          }
+          unit.addOtherEntry(file.getAbsolutePath(), name);
         }
+        return FileVisitResult.CONTINUE;
+      }
 
-        StructClass cl = StructClass.create(new DataInputFullStream(data), isOwn, loader);
-        classes.put(cl.qualifiedName, cl);
-        unit.addClass(cl, cls);
-        loader.addClassLink(cl.qualifiedName, new LazyLoader.Link(path, cls, data));
+      @Override
+      public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+        unit.addDirEntry(dir.toString());
+        return FileVisitResult.CONTINUE;
+      }
+    });
   }
 
-  public Map<String, StructClass> getClasses() {
-    return classes;
+  private void addClass(ContextUnit unit, String name, String externalPath, String internalPath, boolean isOwn, Path path) {
+    addClass(name, isOwn, new ClassProvider(unit, externalPath, internalPath, isOwn, () -> Files.readAllBytes(path)));
+  }
+
+  private void addClass(ContextUnit unit, String name, String externalPath, String internalPath, boolean isOwn, ClassSupplier supplier) {
+    addClass(name, isOwn, new ClassProvider(unit, externalPath, internalPath, isOwn, supplier));
+  }
+
+  private void addClass(String name, boolean isOwn, ClassProvider provider) {
+    if (name == null || name.isEmpty()) {
+      name = provider.get().qualifiedName;
+    }
+    classes.put(name, provider);
+    if (isOwn) ownClasses.put(name, provider.get());
+  }
+
+  public void addData(String path, String cls, byte[] data, boolean isOwn) throws IOException {
+    ContextUnit unit = units.get(path);
+    if (unit == null) {
+      unit = new ContextUnit(ContextUnit.TYPE_FOLDER, path, cls, isOwn, saver, decompiledData);
+      units.put(path, unit);
+    }
+
+    addClass(unit, cls.substring(0, cls.length() - 6), path, cls, isOwn, () -> data);
+  }
+
+  public Map<String, StructClass> getOwnClasses() {
+    return ownClasses;
+  }
+
+  public boolean hasClass(String name) {
+    return classes.containsKey(name);
   }
 
   public boolean instanceOf(String valclass, String refclass) {
@@ -245,5 +267,57 @@ public class StructContext {
   public String renameAbstractParameter(String className, String methodName, String descriptor, int index, String _default) {
     List<String> params = this.abstractNames.get(className + ' ' + methodName + ' ' + descriptor);
     return params != null && index < params.size() ? params.get(index) : _default;
+  }
+
+  class ClassProvider {
+    final ContextUnit unit;
+    private final String externalPath;
+    private final String internalPath;
+    private volatile ClassSupplier supplier;
+    private final boolean own;
+    private StructClass value;
+
+    ClassProvider(ContextUnit unit, String externalPath, String internalPath, boolean own, ClassSupplier supplier) {
+      this.unit = unit;
+      this.externalPath = externalPath;
+      this.internalPath = internalPath;
+      this.own = own;
+      this.supplier = supplier;
+    }
+
+    ClassProvider(StructClass value) {
+      this.unit = null;
+      this.externalPath = null;
+      this.internalPath = null;
+      this.supplier = null;
+      this.own = value.isOwn();
+      this.value = value;
+    }
+
+    public StructClass get() {
+      StructClass v = value;
+      if (v != null) return v;
+      synchronized (this) {
+        if (supplier == null) return value;
+        try {
+          DecompilerContext.getLogger().writeMessage("  Loading Class: " + internalPath, Severity.INFO);
+          byte[] data = supplier.get();
+          StructClass cl = StructClass.create(new DataInputFullStream(data), own, loader);
+          unit.addClass(cl, internalPath);
+          loader.addClassLink(cl.qualifiedName, new LazyLoader.Link(externalPath, internalPath, data));
+          value = cl;
+          supplier = null;
+          return cl;
+        } catch (IOException ex) {
+          String message = "Corrupted class file: " + internalPath;
+          DecompilerContext.getLogger().writeMessage(message, ex);
+          throw new RuntimeException(ex);
+        }
+      }
+    }
+  }
+
+  interface ClassSupplier {
+    byte[] get() throws IOException;
   }
 }

--- a/src/org/jetbrains/java/decompiler/struct/StructMember.java
+++ b/src/org/jetbrains/java/decompiler/struct/StructMember.java
@@ -2,6 +2,7 @@
 package org.jetbrains.java.decompiler.struct;
 
 import org.jetbrains.java.decompiler.code.CodeConstants;
+import org.jetbrains.java.decompiler.struct.attr.StructCodeAttribute;
 import org.jetbrains.java.decompiler.struct.attr.StructGeneralAttribute;
 import org.jetbrains.java.decompiler.struct.attr.StructLocalVariableTableAttribute;
 import org.jetbrains.java.decompiler.struct.attr.StructLocalVariableTypeTableAttribute;
@@ -45,6 +46,10 @@ public abstract class StructMember {
   }
 
   public static Map<String, StructGeneralAttribute> readAttributes(DataInputFullStream in, ConstantPool pool) throws IOException {
+    return readAttributes(in, pool, true);
+  }
+
+  public static Map<String, StructGeneralAttribute> readAttributes(DataInputFullStream in, ConstantPool pool, boolean readCode) throws IOException {
     int length = in.readUnsignedShort();
     Map<String, StructGeneralAttribute> attributes = new HashMap<>(length);
 
@@ -54,7 +59,7 @@ public abstract class StructMember {
 
       StructGeneralAttribute attribute = StructGeneralAttribute.createAttribute(name);
       int attLength = in.readInt();
-      if (attribute == null) {
+      if (attribute == null || (!readCode && attribute instanceof StructCodeAttribute)) {
         in.discard(attLength);
       }
       else {

--- a/src/org/jetbrains/java/decompiler/struct/StructMethod.java
+++ b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
@@ -39,7 +39,7 @@ public class StructMethod extends StructMember {
 
     String[] values = pool.getClassElement(ConstantPool.METHOD, clQualifiedName, nameIndex, descriptorIndex);
 
-    Map<String, StructGeneralAttribute> attributes = readAttributes(in, pool);
+    Map<String, StructGeneralAttribute> attributes = readAttributes(in, pool, own);
     StructCodeAttribute code = (StructCodeAttribute)attributes.remove(StructGeneralAttribute.ATTRIBUTE_CODE.name);
     if (code != null) {
       attributes.putAll(code.codeAttributes);

--- a/src/org/jetbrains/java/decompiler/struct/lazy/LazyLoader.java
+++ b/src/org/jetbrains/java/decompiler/struct/lazy/LazyLoader.java
@@ -43,9 +43,12 @@ public class LazyLoader {
     }
   }
 
+  public byte[] getClassBytes(String externalPath, String internalPath) throws IOException {
+    return provider.getBytecode(externalPath, internalPath);
+  }
+
   public DataInputFullStream getClassStream(String externalPath, String internalPath) throws IOException {
-    byte[] bytes = provider.getBytecode(externalPath, internalPath);
-    return new DataInputFullStream(bytes);
+    return new DataInputFullStream(getClassBytes(externalPath, internalPath));
   }
 
   public DataInputFullStream getClassStream(String qualifiedClassName) throws IOException {

--- a/test/org/jetbrains/java/decompiler/SingleClassesEntireClasspathTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesEntireClasspathTest.java
@@ -1,0 +1,36 @@
+package org.jetbrains.java.decompiler;
+
+import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
+import org.junit.Test;
+
+public class SingleClassesEntireClasspathTest extends SingleClassesTestBase {
+  @Override
+  protected String[] getDecompilerOptions() {
+    return new String[] {
+      IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1",
+      IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1",
+      IFernflowerPreferences.IGNORE_INVALID_BYTECODE, "1",
+      IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1",
+      IFernflowerPreferences.INCLUDE_ENTIRE_CLASSPATH, "1",
+      IFernflowerPreferences.INLINE_SIMPLE_LAMBDAS, "0"
+    };
+  }
+
+  // TODO: reevaluate behavior, especially with casting
+  @Test public void testGenerics() { doTest("pkg/TestGenerics"); }
+  @Test public void testClassTypes() { doTest("pkg/TestClassTypes"); }
+  @Test public void testClassCast() { doTest("pkg/TestClassCast"); }
+  // TODO: intValue() call where there shouldn't be
+  @Test
+  public void testBoxingConstructor() { doTest("pkg/TestBoxingConstructor"); }
+  @Test public void testLocalsSignature() { doTest("pkg/TestLocalsSignature"); }
+  @Test public void testShadowing() { doTest("pkg/TestShadowing", "pkg/Shadow", "ext/Shadow", "pkg/TestShadowingSuperClass"); }
+  @Test public void testPrimitives() { doTest("pkg/TestPrimitives"); }
+  @Test public void testKotlinConstructor() { doTest("pkg/TestKotlinConstructorKt"); }
+  @Test public void testVarArgCalls() { doTest("pkg/TestVarArgCalls"); }
+  @Test public void testUnionType() { doTest("pkg/TestUnionType"); }
+  @Test public void testNamedSuspendFun2Kt() { doTest("pkg/TestNamedSuspendFun2Kt"); }
+  @Test public void testTryWithResources() { doTest("pkg/TestTryWithResources"); }
+  @Test public void testNestedLoops() { doTest("pkg/TestNestedLoops"); }
+
+}

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -5,8 +5,6 @@ import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
 import org.junit.Test;
 
 public class SingleClassesTest extends SingleClassesTestBase {
-  protected DecompilerTestFixture fixture;
-  
   @Override
   protected String[] getDecompilerOptions() {
     return new String[] {
@@ -14,13 +12,11 @@ public class SingleClassesTest extends SingleClassesTestBase {
       IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1",
       IFernflowerPreferences.IGNORE_INVALID_BYTECODE, "1",
       IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1",
-      IFernflowerPreferences.INCLUDE_ENTIRE_CLASSPATH, "1",
+      IFernflowerPreferences.INCLUDE_ENTIRE_CLASSPATH, "0",
       IFernflowerPreferences.INLINE_SIMPLE_LAMBDAS, "0"
     };
   }
 
-  // TODO: reevaluate behavior, especially with casting
-  @Test public void testGenerics() { doTest("pkg/TestGenerics"); }
   @Test public void testEnhancedForLoops() { doTest("pkg/TestEnhancedForLoops"); }
   @Test public void testPrimitiveNarrowing() { doTest("pkg/TestPrimitiveNarrowing"); }
   @Test public void testClassFields() { doTest("pkg/TestClassFields"); }
@@ -28,10 +24,8 @@ public class SingleClassesTest extends SingleClassesTestBase {
   @Test public void testClassLambda() { doTest("pkg/TestClassLambda"); }
   @Test public void testClassLoop() { doTest("pkg/TestClassLoop"); }
   @Test public void testClassSwitch() { doTest("pkg/TestClassSwitch"); }
-  @Test public void testClassTypes() { doTest("pkg/TestClassTypes"); }
   @Test public void testClassVar() { doTest("pkg/TestClassVar"); }
   @Test public void testClassNestedInitializer() { doTest("pkg/TestClassNestedInitializer"); }
-  @Test public void testClassCast() { doTest("pkg/TestClassCast"); }
   @Test public void testDeprecations() { doTest("pkg/TestDeprecations"); }
   @Test public void testExtendsList() { doTest("pkg/TestExtendsList"); }
   @Test public void testMethodParameters() { doTest("pkg/TestMethodParameters"); }
@@ -56,9 +50,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
   @Test public void testInnerLocal() { doTest("pkg/TestInnerLocal"); }
   @Test public void testInnerSignature() { doTest("pkg/TestInnerSignature"); }
   @Test public void testAnonymousSignature() { doTest("pkg/TestAnonymousSignature"); }
-  @Test public void testLocalsSignature() { doTest("pkg/TestLocalsSignature"); }
   @Test public void testParameterizedTypes() { doTest("pkg/TestParameterizedTypes"); }
-  @Test public void testShadowing() { doTest("pkg/TestShadowing", "pkg/Shadow", "ext/Shadow", "pkg/TestShadowingSuperClass"); }
   @Test public void testStringConcat() { doTest("pkg/TestStringConcat"); }
   @Test public void testJava9StringConcat() { doTest("java9/TestJava9StringConcat"); }
   @Test public void testJava9ModuleInfo() { doTest("java9/module-info"); }
@@ -74,20 +66,17 @@ public class SingleClassesTest extends SingleClassesTestBase {
   @Test public void testSyntheticAccess() { doTest("pkg/TestSyntheticAccess"); }
   @Test public void testIllegalVarName() { doTest("pkg/TestIllegalVarName"); }
   @Test public void testIffSimplification() { doTest("pkg/TestIffSimplification"); }
-  @Test public void testKotlinConstructor() { doTest("pkg/TestKotlinConstructorKt"); }
   @Test public void testAsserts() { doTest("pkg/TestAsserts"); }
   @Test public void testLocalsNames() { doTest("pkg/TestLocalsNames"); }
   @Test public void testAnonymousParamNames() { doTest("pkg/TestAnonymousParamNames"); }
   @Test public void testAnonymousParams() { doTest("pkg/TestAnonymousParams"); }
   @Test public void testAccessReplace() { doTest("pkg/TestAccessReplace"); }
   @Test public void testStringLiterals() { doTest("pkg/TestStringLiterals"); }
-  @Test public void testPrimitives() { doTest("pkg/TestPrimitives"); }
   @Test public void testClashName() { doTest("pkg/TestClashName", "pkg/SharedName1",
           "pkg/SharedName2", "pkg/SharedName3", "pkg/SharedName4", "pkg/NonSharedName",
           "pkg/TestClashNameParent", "ext/TestClashNameParent","pkg/TestClashNameIface", "ext/TestClashNameIface"); }
   @Test public void testSwitchOnEnum() { doTest("pkg/TestSwitchOnEnum");}
   @Test public void testSwitchOnStrings() { doTest("pkg/TestSwitchOnStrings");}
-  @Test public void testVarArgCalls() { doTest("pkg/TestVarArgCalls"); }
   @Test public void testLambdaParams() { doTest("pkg/TestLambdaParams"); }
   @Test public void testInterfaceMethods() { doTest("pkg/TestInterfaceMethods"); }
   @Test public void testConstType() { doTest("pkg/TestConstType"); }
@@ -107,7 +96,6 @@ public class SingleClassesTest extends SingleClassesTestBase {
   @Test public void testFieldSingleAccess() { doTest("pkg/TestFieldSingleAccess"); }
   @Test public void testPackageInfo() { doTest("pkg/package-info"); }
 
-  @Test public void testUnionType() { doTest("pkg/TestUnionType"); }
   @Test public void testInnerClassConstructor2() { doTest("pkg/TestInner2"); }
   @Test public void testInUse() { doTest("pkg/TestInUse"); }
 
@@ -116,17 +104,14 @@ public class SingleClassesTest extends SingleClassesTestBase {
   // TODO: This class fails to decompile
 //  @Test public void testPrivateClasses() { doTest("pkg/PrivateClasses"); }
   @Test public void testSuspendLambda() { doTest("pkg/TestSuspendLambdaKt"); }
-  @Test public void testNamedSuspendFun2Kt() { doTest("pkg/TestNamedSuspendFun2Kt"); }
   @Test public void testGenericArgs() { doTest("pkg/TestGenericArgs"); }
   @Test public void testRecordEmpty() { doTest("records/TestRecordEmpty"); }
   @Test public void testRecordSimple() { doTest("records/TestRecordSimple"); }
   @Test public void testRecordVararg() { doTest("records/TestRecordVararg"); }
   @Test public void testRecordGenericVararg() { doTest("records/TestRecordGenericVararg"); }
   @Test public void testRecordAnno() { doTest("records/TestRecordAnno"); }
-  @Test public void testTryWithResources() { doTest("pkg/TestTryWithResources"); }
   // TODO: The (double) in front of the (int) should be removed
   @Test public void testMultiCast() { doTest("pkg/TestMultiCast"); }
-  @Test public void testNestedLoops() { doTest("pkg/TestNestedLoops"); }
   // TODO: The ternary here needs to be removed
   @Test public void testNestedLambdas() { doTest("pkg/TestNestedLambdas"); }
   @Test public void testSwitchAssign() { doTest("pkg/TestSwitchAssign"); }
@@ -158,8 +143,6 @@ public class SingleClassesTest extends SingleClassesTestBase {
   @Test public void testAssignmentInDoWhile() { doTest("pkg/TestAssignmentInDoWhile"); }
   // TODO: Assignment of a = a is removed
   @Test public void testBooleanAssignment() { doTest("pkg/TestBooleanAssignment"); }
-  // TODO: intValue() call where there shouldn't be
-  @Test public void testBoxingConstructor() { doTest("pkg/TestBoxingConstructor"); }
   @Test public void testCastPrimitiveToObject() { doTest("pkg/TestCastPrimitiveToObject"); }
   @Test public void testDoWhileTrue() { doTest("pkg/TestDoWhileTrue"); }
   @Test public void testExtraClass() { doTest("pkg/TestExtraClass"); }


### PR DESCRIPTION
Here are some performance improvements, mainly focused on making tests run faster, but these are also generally useful.

- Run tests requiring the "include entire classpath" option separately
	- That option adds ~500ms of setup time to each test, only use it where it affects the output
- Lazy load all library classes
	- This also makes the decompiles using "include entire classpath" faster
- Only read Code attributes of own methods
	- Parsing the Code attribute of libraries is not necessary, so some time can be saved by skipping it