### PR TITLE
Fix concurrent writing issues in single file saver

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/decompiler/SingleFileSaver.java
+++ b/src/org/jetbrains/java/decompiler/main/decompiler/SingleFileSaver.java
@@ -80,7 +80,7 @@ public class SingleFileSaver implements IResultSaver {
   }
 
   @Override
-  public void saveClassEntry(String path, String archiveName, String qualifiedName, String entryName, String content) {
+  public synchronized void saveClassEntry(String path, String archiveName, String qualifiedName, String entryName, String content) {
     if (!checkEntry(entryName))
         return;
 


### PR DESCRIPTION
ZipOutputStream is not concurrent, so it is clear that this would create
such issues. Of course this fix is not the most ideal fix out there, but
a real fix would require getting a concurrent variant ZipOutputStream
which I do not believe is worth it.