### PR TITLE
Fix duplicate local variable names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,32 +65,23 @@ task testDataClasses {
 }
 testClasses.dependsOn(testDataClasses)
 
-[8, 9, 11, 16].forEach {version ->
-  def sourceSet = sourceSets.create("testDataJava${version}") {
-    it.java.srcDirs file("testData/src/java${version}")
+void createJavaTestDataSet(int version, String suffix = "", List<String> compilerArgs = []) {
+  sourceSets.create("testDataJava${version}${suffix}") {
+    it.java.srcDirs file("testData/src/java${version}${suffix.toLowerCase()}")
   }
-  def task = tasks.getByName("compileTestDataJava${version}Java") {
-    destinationDir = file("testData/classes/java${version}")
+  tasks.getByName("compileTestDataJava${version}${suffix}Java") {
+    destinationDir = file("testData/classes/java${version}${suffix.toLowerCase()}")
     javaCompiler = javaToolchains.compilerFor {
       languageVersion = JavaLanguageVersion.of(version)
     }
+    options.compilerArgs = compilerArgs
   }
-  testDataClasses.dependsOn("testDataJava${version}Classes")
+  testDataClasses.dependsOn("testDataJava${version}${suffix}Classes")
 }
 
-[16].forEach {version ->
-  def sourceSet = sourceSets.create("testDataJava${version}Preview") {
-    it.java.srcDirs file("testData/src/java${version}preview")
-  }
-  def task = tasks.getByName("compileTestDataJava${version}PreviewJava") {
-    destinationDir = file("testData/classes/java${version}preview")
-    javaCompiler = javaToolchains.compilerFor {
-      languageVersion = JavaLanguageVersion.of(version)
-    }
-    options.compilerArgs = ["--enable-preview"]
-  }
-  testDataClasses.dependsOn("testDataJava${version}PreviewClasses")
-}
+[8, 9, 11, 16].forEach { version -> createJavaTestDataSet(version) }
+[16].forEach { version -> createJavaTestDataSet(version, "Preview", ["--enable-preview"]) }
+[8].forEach { version -> createJavaTestDataSet(version, "NoDebug", ["-g:none"])}
 
 task compileTestDataJasm(type: JasmCompile) {
   source = fileTree("testData/src/jasm/")

--- a/src/org/jetbrains/java/decompiler/main/collectors/VarNamesCollector.java
+++ b/src/org/jetbrains/java/decompiler/main/collectors/VarNamesCollector.java
@@ -2,6 +2,7 @@
 package org.jetbrains.java.decompiler.main.collectors;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -12,11 +13,15 @@ public class VarNamesCollector {
   public VarNamesCollector() { }
 
   public VarNamesCollector(Collection<String> setNames) {
-    usedNames.addAll(setNames);
+    addNames(setNames);
   }
 
   public void addName(String value) {
     usedNames.add(value);
+  }
+
+  public void addNames(Collection<String> names) {
+    usedNames.addAll(names);
   }
 
   public String getFreeName(int index) {
@@ -27,7 +32,11 @@ public class VarNamesCollector {
     while (usedNames.contains(proposition)) {
       proposition += "x";
     }
-    usedNames.add(proposition);
+    addName(proposition);
     return proposition;
+  }
+
+  public Set<String> getUsedNames() {
+    return Collections.unmodifiableSet(usedNames);
   }
 }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
@@ -74,7 +74,9 @@ public class VarDefinitionHelper {
     for (int i = 0; i < paramcount; i++) {
       implDefVars.add(varindex);
       VarVersionPair vpp = new VarVersionPair(varindex, 0);
-      varproc.setVarName(vpp, vc.getFreeName(varindex));
+      if (varindex != 0 || !thisvar) {
+        varproc.setVarName(vpp, vc.getFreeName(varindex));
+      }
 
       if (thisvar) {
         if (i == 0) {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarProcessor.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarProcessor.java
@@ -25,6 +25,7 @@ public class VarProcessor {
   private VarVersionsProcessor varVersions;
   private final Map<VarVersionPair, String> thisVars = new HashMap<>();
   private final Set<VarVersionPair> externalVars = new HashSet<>();
+  public boolean nestedProcessed;
 
   public VarProcessor(StructMethod mt, MethodDescriptor md) {
     method = mt;

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -223,5 +223,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_16_PREVIEW, "PermittedSubClassC", "TestSealedInterfaces");
     register(JAVA_16_PREVIEW, "PermittedSubClassD", "PermittedSubClassC", "TestSealedInterfaces");
     register(JAVA_16_PREVIEW, "PermittedSubClassE", "TestSealedInterfaces");
+
+    register(JAVA_8_NODEBUG, "TestDuplicateLocals");
   }
 }

--- a/test/org/jetbrains/java/decompiler/SingleClassesTestBase.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTestBase.java
@@ -179,10 +179,11 @@ public abstract class SingleClassesTestBase {
     enum Version {
       CUSTOM("custom", "Custom"),
       JAVA_8(8),
+      JAVA_8_NODEBUG(8, "nodebug", "No Debug Info"),
       JAVA_9(9),
       JAVA_11(11),
       JAVA_16(16),
-      JAVA_16_PREVIEW(16, true),
+      JAVA_16_PREVIEW(16, "preview", "Preview"),
       GROOVY("groovy", "Groovy"),
       KOTLIN("kt", "Kotlin"),
       JASM("jasm", "Custom (jasm)"),
@@ -197,11 +198,11 @@ public abstract class SingleClassesTestBase {
       }
 
       Version(int javaVersion) {
-        this(javaVersion, false);
+        this(javaVersion, "", "");
       }
 
-      Version(int javaVersion, boolean preview) {
-        this("java" + javaVersion + (preview ? "preview" : ""), "Java " + javaVersion + (preview ? " Preview" : ""));
+      Version(int javaVersion, String suffix, String display) {
+        this("java" + javaVersion + suffix, "Java " + javaVersion + (!display.isEmpty() ? " " + display : ""));
       }
 
       @Override

--- a/testData/results/pkg/TestDuplicateLocals.dec
+++ b/testData/results/pkg/TestDuplicateLocals.dec
@@ -1,13 +1,14 @@
 package pkg;
 
 import java.util.List;
+import java.util.Map;
 
 public class TestDuplicateLocals {
    public void test1(List<List<Object>> var1) {
       System.out.println(var1);
       var1.forEach(var0 -> {
          System.out.println(var0);
-         var0.forEach(var1 -> {
+         var0.forEach(var1x -> {
             System.out.println(var0);
          });
       });
@@ -17,8 +18,29 @@ public class TestDuplicateLocals {
       System.out.println(var0);
       var0.forEach(var0x -> {
          System.out.println(var0x);
-         var0x.forEach(var0 -> {
-            System.out.println(var0);
+         var0x.forEach(var0xx -> {
+            System.out.println(var0xx);
+         });
+      });
+   }
+
+   public void test3(List<List<Object>> var1) {
+      System.out.println(var1);
+      var1.forEach(var0 -> {
+         int var1 = var0.size();
+         System.out.println(var0);
+         var0.forEach(var1x -> {
+            System.out.println(var1);
+         });
+      });
+   }
+
+   public void test4(Map<String, List<Object>> var1) {
+      System.out.println(var1);
+      var1.forEach((var1x, var2) -> {
+         System.out.println(var1x);
+         var1.forEach((var1xx, var2x) -> {
+            System.out.println(var1x);
          });
       });
    }
@@ -26,93 +48,190 @@ public class TestDuplicateLocals {
 
 class 'pkg/TestDuplicateLocals' {
    method 'lambda$null$0 (Ljava/util/List;Ljava/lang/Object;)V' {
-      0      10
-      1      10
-      2      10
-      3      10
-      4      10
-      5      10
-      6      10
-      7      11
+      0      11
+      1      11
+      2      11
+      3      11
+      4      11
+      5      11
+      6      11
+      7      12
    }
 
    method 'lambda$test1$1 (Ljava/util/List;)V' {
-      2      8
-      3      8
-      4      8
-      5      8
-      6      8
-      7      8
-      8      8
-      9      9
-      10      9
-      11      9
-      12      9
-      13      9
-      14      9
-      15      12
+      2      9
+      3      9
+      4      9
+      5      9
+      6      9
+      7      9
+      8      9
+      9      10
+      10      10
+      11      10
+      12      10
+      13      10
+      14      10
+      15      13
    }
 
    method 'test1 (Ljava/util/List;)V' {
-      0      6
-      1      6
-      2      6
-      3      6
-      4      6
-      5      6
-      6      6
-      7      7
-      d      7
-      e      7
-      f      7
-      10      7
-      11      7
-      12      13
+      0      7
+      1      7
+      2      7
+      3      7
+      4      7
+      5      7
+      6      7
+      7      8
+      d      8
+      e      8
+      f      8
+      10      8
+      11      8
+      12      14
    }
 
    method 'lambda$null$2 (Ljava/lang/Object;)V' {
-      0      20
-      1      20
-      2      20
-      3      20
-      4      20
-      5      20
-      6      20
-      7      21
+      0      21
+      1      21
+      2      21
+      3      21
+      4      21
+      5      21
+      6      21
+      7      22
    }
 
    method 'lambda$test2$3 (Ljava/util/List;)V' {
-      0      18
-      1      18
-      2      18
-      3      18
-      4      18
-      5      18
-      6      18
-      7      19
-      d      19
-      e      19
-      f      19
-      10      19
-      11      19
-      12      22
+      0      19
+      1      19
+      2      19
+      3      19
+      4      19
+      5      19
+      6      19
+      7      20
+      d      20
+      e      20
+      f      20
+      10      20
+      11      20
+      12      23
    }
 
    method 'test2 (Ljava/util/List;)V' {
-      0      16
-      1      16
-      2      16
-      3      16
-      4      16
-      5      16
-      6      16
-      7      17
-      d      17
-      e      17
-      f      17
-      10      17
-      11      17
-      12      23
+      0      17
+      1      17
+      2      17
+      3      17
+      4      17
+      5      17
+      6      17
+      7      18
+      d      18
+      e      18
+      f      18
+      10      18
+      11      18
+      12      24
+   }
+
+   method 'lambda$null$4 (ILjava/lang/Object;)V' {
+      0      32
+      1      32
+      2      32
+      3      32
+      4      32
+      5      32
+      6      32
+      7      33
+   }
+
+   method 'lambda$test3$5 (Ljava/util/List;)V' {
+      0      29
+      1      29
+      2      29
+      3      29
+      4      29
+      5      29
+      6      29
+      7      30
+      8      30
+      9      30
+      a      30
+      b      30
+      c      30
+      d      30
+      e      31
+      15      31
+      16      31
+      17      31
+      18      31
+      19      31
+      1a      34
+   }
+
+   method 'test3 (Ljava/util/List;)V' {
+      0      27
+      1      27
+      2      27
+      3      27
+      4      27
+      5      27
+      6      27
+      7      28
+      d      28
+      e      28
+      f      28
+      10      28
+      11      28
+      12      35
+   }
+
+   method 'lambda$null$6 (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V' {
+      0      42
+      1      42
+      2      42
+      3      42
+      4      42
+      5      42
+      6      42
+      7      43
+   }
+
+   method 'lambda$test4$7 (Ljava/util/Map;Ljava/lang/String;Ljava/util/List;)V' {
+      0      40
+      1      40
+      2      40
+      3      40
+      4      40
+      5      40
+      6      40
+      7      41
+      e      41
+      f      41
+      10      41
+      11      41
+      12      41
+      13      44
+   }
+
+   method 'test4 (Ljava/util/Map;)V' {
+      0      38
+      1      38
+      2      38
+      3      38
+      4      38
+      5      38
+      6      38
+      7      39
+      e      39
+      f      39
+      10      39
+      11      39
+      12      39
+      13      45
    }
 }
 

--- a/testData/results/pkg/TestDuplicateLocals.dec
+++ b/testData/results/pkg/TestDuplicateLocals.dec
@@ -1,0 +1,119 @@
+package pkg;
+
+import java.util.List;
+
+public class TestDuplicateLocals {
+   public void test1(List<List<Object>> var1) {
+      System.out.println(var1);
+      var1.forEach(var0 -> {
+         System.out.println(var0);
+         var0.forEach(var1 -> {
+            System.out.println(var0);
+         });
+      });
+   }
+
+   public static void test2(List<List<Object>> var0) {
+      System.out.println(var0);
+      var0.forEach(var0x -> {
+         System.out.println(var0x);
+         var0x.forEach(var0 -> {
+            System.out.println(var0);
+         });
+      });
+   }
+}
+
+class 'pkg/TestDuplicateLocals' {
+   method 'lambda$null$0 (Ljava/util/List;Ljava/lang/Object;)V' {
+      0      10
+      1      10
+      2      10
+      3      10
+      4      10
+      5      10
+      6      10
+      7      11
+   }
+
+   method 'lambda$test1$1 (Ljava/util/List;)V' {
+      2      8
+      3      8
+      4      8
+      5      8
+      6      8
+      7      8
+      8      8
+      9      9
+      10      9
+      11      9
+      12      9
+      13      9
+      14      9
+      15      12
+   }
+
+   method 'test1 (Ljava/util/List;)V' {
+      0      6
+      1      6
+      2      6
+      3      6
+      4      6
+      5      6
+      6      6
+      7      7
+      d      7
+      e      7
+      f      7
+      10      7
+      11      7
+      12      13
+   }
+
+   method 'lambda$null$2 (Ljava/lang/Object;)V' {
+      0      20
+      1      20
+      2      20
+      3      20
+      4      20
+      5      20
+      6      20
+      7      21
+   }
+
+   method 'lambda$test2$3 (Ljava/util/List;)V' {
+      0      18
+      1      18
+      2      18
+      3      18
+      4      18
+      5      18
+      6      18
+      7      19
+      d      19
+      e      19
+      f      19
+      10      19
+      11      19
+      12      22
+   }
+
+   method 'test2 (Ljava/util/List;)V' {
+      0      16
+      1      16
+      2      16
+      3      16
+      4      16
+      5      16
+      6      16
+      7      17
+      d      17
+      e      17
+      f      17
+      10      17
+      11      17
+      12      23
+   }
+}
+
+Lines mapping:

--- a/testData/src/java8nodebug/pkg/TestDuplicateLocals.java
+++ b/testData/src/java8nodebug/pkg/TestDuplicateLocals.java
@@ -1,12 +1,13 @@
 package pkg;
 
 import java.util.List;
+import java.util.Map;
 
 public class TestDuplicateLocals {
   public void test1(List<List<Object>> a) {
     System.out.println(a);
     a.forEach(b -> {
-      List<Object> c = b;
+      List<Object> c = b; // increase the lvt index
       System.out.println(b);
       b.forEach(d -> System.out.println(c));
     });
@@ -17,6 +18,23 @@ public class TestDuplicateLocals {
     a.forEach(b -> {
       System.out.println(b);
       b.forEach(c -> System.out.println(c));
+    });
+  }
+
+  public void test3(List<List<Object>> a) {
+    System.out.println(a);
+    a.forEach(b -> {
+      int c = b.size();
+      System.out.println(b);
+      b.forEach(d -> System.out.println(c));
+    });
+  }
+
+  public void test4(Map<String, List<Object>> a) {
+    System.out.println(a);
+    a.forEach((b, c) -> {
+      System.out.println(b);
+      a.forEach((d, e) -> System.out.println(b));
     });
   }
 }

--- a/testData/src/java8nodebug/pkg/TestDuplicateLocals.java
+++ b/testData/src/java8nodebug/pkg/TestDuplicateLocals.java
@@ -1,0 +1,22 @@
+package pkg;
+
+import java.util.List;
+
+public class TestDuplicateLocals {
+  public void test1(List<List<Object>> a) {
+    System.out.println(a);
+    a.forEach(b -> {
+      List<Object> c = b;
+      System.out.println(b);
+      b.forEach(d -> System.out.println(c));
+    });
+  }
+
+  public static void test2(List<List<Object>> a) {
+    System.out.println(a);
+    a.forEach(b -> {
+      System.out.println(b);
+      b.forEach(c -> System.out.println(c));
+    });
+  }
+}


### PR DESCRIPTION
In cases where there was no lvt or the lvt was somehow generated (e.g. by a remapper) without considering nested methods quiltflower would sometimes generate variable/parameter names that were already used by an enclosing method.