### PR TITLE
Add jrt option as a lightweight alternative to iec

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/Fernflower.java
+++ b/src/org/jetbrains/java/decompiler/main/Fernflower.java
@@ -11,6 +11,7 @@ import org.jetbrains.java.decompiler.struct.StructClass;
 import org.jetbrains.java.decompiler.struct.StructContext;
 import org.jetbrains.java.decompiler.struct.lazy.LazyLoader;
 import org.jetbrains.java.decompiler.util.JADNameProvider;
+import org.jetbrains.java.decompiler.util.JrtFinder;
 import org.jetbrains.java.decompiler.util.TextBuffer;
 import org.jetbrains.java.decompiler.util.ClasspathScanner;
 
@@ -80,6 +81,8 @@ public class Fernflower implements IDecompiledData {
 
     if (DecompilerContext.getOption(IFernflowerPreferences.INCLUDE_ENTIRE_CLASSPATH)) {
       ClasspathScanner.addAllClasspath(structContext);
+    } else if (DecompilerContext.getOption(IFernflowerPreferences.INCLUDE_JAVA_RUNTIME)) {
+      JrtFinder.addJrt(structContext);
     }
   }
 

--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
@@ -38,6 +38,7 @@ public interface IFernflowerPreferences {
   String PATTERN_MATCHING = "pam";
 
   String INCLUDE_ENTIRE_CLASSPATH = "iec";
+  String INCLUDE_JAVA_RUNTIME = "jrt";
   String EXPLICIT_GENERIC_ARGUMENTS = "ega";
   String INLINE_SIMPLE_LAMBDAS = "isl";
 
@@ -97,6 +98,7 @@ public interface IFernflowerPreferences {
     defaults.put(PATTERN_MATCHING, "0");
 
     defaults.put(INCLUDE_ENTIRE_CLASSPATH, "0");
+    defaults.put(INCLUDE_JAVA_RUNTIME, "0");
     defaults.put(EXPLICIT_GENERIC_ARGUMENTS, "0");
     defaults.put(INLINE_SIMPLE_LAMBDAS, "1");
 

--- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
+++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
@@ -74,6 +74,22 @@ public class StructContext {
     addSpace("", file, isOwn, 0);
   }
 
+  public void addSpace(FileSystem fs, boolean isOwn) {
+    String scheme = fs.provider().getScheme();
+    if ("jar".equals(scheme)) {
+      String fileUri = fs.getPath("/").toUri().getSchemeSpecificPart();
+      fileUri = fileUri.substring(0, fileUri.indexOf('!'));
+      addSpace(Paths.get(fileUri).toFile(), false);
+    } else {
+      try {
+        addFileSystem(fs, "", new File(fs.toString()), ContextUnit.TYPE_JAR, isOwn);
+      } catch (IOException e) {
+        DecompilerContext.getLogger().writeMessage("Corrupted file system: " + fs, e);
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
   private void addSpace(String path, File file, boolean isOwn, int level) {
     if (file.isDirectory()) {
       if (level == 1) path += file.getName();
@@ -147,11 +163,20 @@ public class StructContext {
   private void addArchive(String externalPath, File file, int type, boolean isOwn) throws IOException {
     DecompilerContext.getLogger().writeMessage("Adding Archive: " + file.getAbsolutePath(), Severity.INFO);
     FileSystem fs = getZipFileSystem(file);
-    ContextUnit unit = units.computeIfAbsent(externalPath + "/" + file.getName(), k -> new ContextUnit(type, externalPath, file.getName(), isOwn, saver, decompiledData));
+    addFileSystem(fs, externalPath, file, type, isOwn);
+  }
+
+  private void addFileSystem(FileSystem fs, String externalPath, File file, int type, boolean isOwn) throws IOException {
+    ContextUnit unit = units.computeIfAbsent(externalPath + "/" + file, k -> new ContextUnit(type, externalPath, file.getName(), isOwn, saver, decompiledData));
     Files.walkFileTree(fs.getPath("/"), new SimpleFileVisitor<Path>() {
       @Override
       public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
-        String name = path.toString().substring(1);
+        String name;
+        if (path.getNameCount() > 2 && "modules".equals(path.getName(0).toString()) && "jrt".equals(path.getFileSystem().provider().getScheme())) {
+          name = path.subpath(2, path.getNameCount()).toString();
+        } else {
+          name = path.toString().substring(1);
+        }
         if (name.endsWith(".class")) {
           addClass(unit, name.substring(0, name.length() - 6), file.getAbsolutePath(), path.toString().substring(1), isOwn, path);
         } else {

--- a/src/org/jetbrains/java/decompiler/util/JrtFinder.java
+++ b/src/org/jetbrains/java/decompiler/util/JrtFinder.java
@@ -1,0 +1,44 @@
+package org.jetbrains.java.decompiler.util;
+
+import org.jetbrains.java.decompiler.main.DecompilerContext;
+import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
+import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger.Severity;
+import org.jetbrains.java.decompiler.struct.StructContext;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class JrtFinder {
+  public static void addJrt(StructContext ctx) {
+    IFernflowerLogger logger = DecompilerContext.getLogger();
+    try {
+      URL objectUrl = Object.class.getResource("/java/lang/Object.class");
+      if (objectUrl == null) {
+        logger.writeMessage("Could not locate Java runtime", Severity.WARN);
+        return;
+      }
+      URI objectUri = objectUrl.toURI();
+      switch (objectUri.getScheme()) {
+        case "jar":
+          String fileUri = objectUri.getSchemeSpecificPart();
+          fileUri = fileUri.substring(0, fileUri.indexOf('!'));
+          Path jarPath = Paths.get(new URI(fileUri));
+          ctx.addSpace(jarPath.toFile(), false);
+          break;
+        case "jrt":
+          Path objectPath = Paths.get(objectUri);
+          FileSystem jrtFs = objectPath.getFileSystem();
+          ctx.addSpace(jrtFs, false);
+          break;
+        default:
+          logger.writeMessage("Unknown file system for Java runtime: " + objectUri.getScheme(), Severity.WARN);
+      }
+    } catch (URISyntaxException e) {
+      logger.writeMessage("Could not locate Java runtime", Severity.WARN, e);
+    }
+  }
+}

--- a/test/org/jetbrains/java/decompiler/SingleClassesEntireClasspathTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesEntireClasspathTest.java
@@ -19,39 +19,8 @@ public class SingleClassesEntireClasspathTest extends SingleClassesTestBase {
 
   @Override
   protected void registerAll() {
-    // TODO: reevaluate behavior, especially with casting
-    register(JAVA_8, "TestGenerics");
-    register(JAVA_8, "TestClassTypes");
-    register(JAVA_8, "TestClassCast");
-    // TODO: intValue() call where there shouldn't be
-    register(JAVA_8, "TestBoxingConstructor");
-    register(JAVA_8, "TestLocalsSignature");
-    register(JAVA_8, "TestShadowing", "Shadow", "ext/Shadow", "TestShadowingSuperClass");
-    register(JAVA_8, "TestPrimitives");
+    // These have better results with the kotlin standard library from the classpath
     register(KOTLIN, "TestKotlinConstructorKt");
-    register(JAVA_8, "TestVarArgCalls");
-    register(JAVA_8, "TestUnionType");
     register(KOTLIN, "TestNamedSuspendFun2Kt");
-    register(JAVA_8, "TestTryWithResources");
-    register(JAVA_8, "TestNestedLoops");
-    register(JAVA_8, "TestAnonymousClass");
-    // TODO: Object[] becomes <unknown>
-    register(JAVA_8, "TestObjectArrays");
-    register(JAVA_8, "TestAnonymousParams");
-    register(JAVA_8, "TestThrowException");
-    register(JAVA_8, "TestClassSimpleBytecodeMapping");
-    register(JAVA_8, "TestAnonymousSignature");
-    register(JAVA_16, "TestTryWithResourcesJ16");
-    register(JAVA_16, "TestTryWithResourcesCatchJ16");
-    register(JAVA_16, "TestTryWithResourcesMultiJ16");
-    register(JAVA_16, "TestTryWithResourcesFinallyJ16");
-    register(JAVA_16, "TestTryWithResourcesCatchFinallyJ16");
-    // TODO: returning in finally causes broken control flow and undecompileable methods
-    register(JAVA_16, "TestTryWithResourcesReturnJ16");
-    register(JAVA_16, "TestTryWithResourcesNestedJ16");
-    // TODO: extra casts, var type reverted to object
-    register(JAVA_16, "TestTryWithResourcesNullJ16");
-    // TODO: doesn't make try with resources block
-    register(JAVA_16, "TestTryWithResourcesOuterJ16");
   }
 }

--- a/test/org/jetbrains/java/decompiler/SingleClassesJavaRuntimeTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesJavaRuntimeTest.java
@@ -1,0 +1,55 @@
+package org.jetbrains.java.decompiler;
+
+import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
+
+import static org.jetbrains.java.decompiler.SingleClassesTestBase.TestDefinition.Version.*;
+
+public class SingleClassesJavaRuntimeTest extends SingleClassesTestBase {
+  @Override
+  protected String[] getDecompilerOptions() {
+    return new String[] {
+      IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1",
+      IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1",
+      IFernflowerPreferences.IGNORE_INVALID_BYTECODE, "1",
+      IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1",
+      IFernflowerPreferences.INCLUDE_JAVA_RUNTIME, "1",
+      IFernflowerPreferences.INLINE_SIMPLE_LAMBDAS, "0"
+    };
+  }
+
+  @Override
+  protected void registerAll() {
+    // TODO: reevaluate behavior, especially with casting
+    register(JAVA_8, "TestGenerics");
+    register(JAVA_8, "TestClassTypes");
+    register(JAVA_8, "TestClassCast");
+    // TODO: intValue() call where there shouldn't be
+    register(JAVA_8, "TestBoxingConstructor");
+    register(JAVA_8, "TestLocalsSignature");
+    register(JAVA_8, "TestShadowing", "Shadow", "ext/Shadow", "TestShadowingSuperClass");
+    register(JAVA_8, "TestPrimitives");
+    register(JAVA_8, "TestVarArgCalls");
+    register(JAVA_8, "TestUnionType");
+    register(JAVA_8, "TestTryWithResources");
+    register(JAVA_8, "TestNestedLoops");
+    register(JAVA_8, "TestAnonymousClass");
+    // TODO: Object[] becomes <unknown>
+    register(JAVA_8, "TestObjectArrays");
+    register(JAVA_8, "TestAnonymousParams");
+    register(JAVA_8, "TestThrowException");
+    register(JAVA_8, "TestClassSimpleBytecodeMapping");
+    register(JAVA_8, "TestAnonymousSignature");
+    register(JAVA_16, "TestTryWithResourcesJ16");
+    register(JAVA_16, "TestTryWithResourcesCatchJ16");
+    register(JAVA_16, "TestTryWithResourcesMultiJ16");
+    register(JAVA_16, "TestTryWithResourcesFinallyJ16");
+    register(JAVA_16, "TestTryWithResourcesCatchFinallyJ16");
+    // TODO: returning in finally causes broken control flow and undecompileable methods
+    register(JAVA_16, "TestTryWithResourcesReturnJ16");
+    register(JAVA_16, "TestTryWithResourcesNestedJ16");
+    // TODO: extra casts, var type reverted to object
+    register(JAVA_16, "TestTryWithResourcesNullJ16");
+    // TODO: doesn't make try with resources block
+    register(JAVA_16, "TestTryWithResourcesOuterJ16");
+  }
+}

--- a/test/org/jetbrains/java/decompiler/SingleClassesTestBase.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTestBase.java
@@ -24,6 +24,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.jetbrains.java.decompiler.DecompilerTestFixture.assertFilesEqual;
@@ -172,9 +173,9 @@ public abstract class SingleClassesTestBase {
 
     Path parent = classFile.getParent();
     if (parent != null) {
-      final String pattern = classFile.getFileName().toString().replace(".class", "") + "\\$.+\\.class";
+      final Pattern pattern = Pattern.compile(classFile.getFileName().toString().replace(".class", "") + "\\$.+\\.class");
       try {
-        Files.list(parent).filter(p -> p.getFileName().toString().matches(pattern)).forEach(files::add);
+        Files.list(parent).filter(p -> pattern.matcher(p.getFileName().toString()).matches()).forEach(files::add);
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }


### PR DESCRIPTION
This just adds the Java runtime instead of the whole classpath as a library.

Either by using the `rt.jar` as a JAR or in Java 9+ by iterating over the `jrt:` file system