### PR TITLE
Fix Kotlin appearing in the POM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
   testDataGroovyImplementation 'org.codehaus.groovy:groovy:3.0.8'
   testDataKotlinImplementation platform('org.jetbrains.kotlin:kotlin-bom')
   testDataKotlinImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+  testRuntimeOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
The Kotlin Gradle plugin has this "feature" where it adds the stdlib as an `implementation` dep automatically. Unfortunately, this is unwanted really often.