### PR TITLE
TextBuffer assertions

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -1329,7 +1329,7 @@ public class ClassWriter {
       StructAnnotationAttribute attribute = (StructAnnotationAttribute)mb.getAttribute(key);
       if (attribute != null) {
         for (AnnotationExprent annotation : attribute.getAnnotations()) {
-          String text = annotation.toJava(indent).toString();
+          String text = annotation.toJava(indent).convertToStringAndAllowDataDiscard();
           filter.add(text);
           buffer.append(text);
           if (indent < 0) {
@@ -1400,7 +1400,7 @@ public class ClassWriter {
         List<List<AnnotationExprent>> annotations = attribute.getParamAnnotations();
         if (param < annotations.size()) {
           for (AnnotationExprent annotation : annotations.get(param)) {
-            String text = annotation.toJava(-1).toString();
+            String text = annotation.toJava(-1).convertToStringAndAllowDataDiscard();
             filter.add(text);
             buffer.append(text).append(' ');
           }
@@ -1417,7 +1417,7 @@ public class ClassWriter {
       if (attribute != null) {
         for (TypeAnnotation annotation : attribute.getAnnotations()) {
           if (annotation.isTopLevel() && annotation.getTargetType() == targetType && (index < 0 || annotation.getIndex() == index)) {
-            String text = annotation.getAnnotation().toJava(indent).toString();
+            String text = annotation.getAnnotation().toJava(indent).convertToStringAndAllowDataDiscard();
             if (!filter.contains(text)) {
               buffer.append(text);
               if (indent < 0) {

--- a/src/org/jetbrains/java/decompiler/main/Fernflower.java
+++ b/src/org/jetbrains/java/decompiler/main/Fernflower.java
@@ -147,7 +147,7 @@ public class Fernflower implements IDecompiledData {
       TextBuffer buffer = new TextBuffer(ClassesProcessor.AVERAGE_CLASS_SIZE);
       buffer.append(DecompilerContext.getProperty(IFernflowerPreferences.BANNER).toString());
       classProcessor.writeClass(cl, buffer);
-      return buffer.toString();
+      return buffer.convertToStringAndAllowDataDiscard();
     }
     catch (Throwable t) {
       DecompilerContext.getLogger().writeMessage("Class " + cl.qualifiedName + " couldn't be fully decompiled.", t);

--- a/src/org/jetbrains/java/decompiler/main/RecordHelper.java
+++ b/src/org/jetbrains/java/decompiler/main/RecordHelper.java
@@ -125,7 +125,7 @@ public final class RecordHelper {
         StructAnnotationAttribute attribute = (StructAnnotationAttribute) member.getAttribute(key);
         if (attribute == null) continue;
         for (AnnotationExprent annotation : attribute.getAnnotations()) {
-          String text = annotation.toJava(-1).toString();
+          String text = annotation.toJava(-1).convertToStringAndAllowDataDiscard();
           annotations.add(text);
         }
       }
@@ -137,7 +137,7 @@ public final class RecordHelper {
           if (!annotation.isTopLevel()) continue;
           int type = annotation.getTargetType();
           if (type == TypeAnnotation.FIELD || type == TypeAnnotation.METHOD_PARAMETER) {
-            String text = annotation.getAnnotation().toJava(-1).toString();
+            String text = annotation.getAnnotation().toJava(-1).convertToStringAndAllowDataDiscard();
             annotations.add(text);
           }
         }
@@ -153,7 +153,7 @@ public final class RecordHelper {
       List<List<AnnotationExprent>> paramAnnotations = attribute.getParamAnnotations();
       if (param >= paramAnnotations.size()) continue;
       for (AnnotationExprent annotation : paramAnnotations.get(param)) {
-        String text = annotation.toJava(-1).toString();
+        String text = annotation.toJava(-1).convertToStringAndAllowDataDiscard();
         annotations.add(text);
       }
     }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
@@ -531,7 +531,7 @@ public class ConstExprent extends Exprent {
 
   @Override
   public String toString() {
-    return "const(" + toJava(0) + ")";
+    return "const(" + toJava(0).convertToStringAndAllowDataDiscard() + ")";
   }
 
   // *****************************************************************************

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
@@ -382,6 +382,6 @@ public abstract class Exprent implements IMatchable {
 
   @Override
   public String toString() {
-    return toJava(0).toString();
+    return toJava(0).convertToStringAndAllowDataDiscard();
   }
 }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
@@ -184,7 +184,7 @@ public class FieldExprent extends Exprent {
         buf.append(buff);
       }
 
-      if (buf.toString().equals(
+      if (buf.contentEquals(
         VarExprent.VAR_NAMELESS_ENCLOSURE)) { // FIXME: workaround for field access of an anonymous enclosing class. Find a better way.
         buf.setLength(0);
       }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
@@ -675,7 +675,7 @@ public class InvocationExprent extends Exprent {
 
     switch (functype) {
       case TYP_GENERAL:
-        if (VarExprent.VAR_NAMELESS_ENCLOSURE.equals(buf.toString())) {
+        if (buf.contentEquals(VarExprent.VAR_NAMELESS_ENCLOSURE)) {
           buf = new TextBuffer();
         }
 

--- a/src/org/jetbrains/java/decompiler/util/TextBuffer.java
+++ b/src/org/jetbrains/java/decompiler/util/TextBuffer.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 @SuppressWarnings("UnusedReturnValue")
 public class TextBuffer {
-  private static final boolean ALLOW_TO_STRING = Boolean.getBoolean("decompiler.allow.to.string");
+  private static final boolean ALLOW_TO_STRING = Boolean.getBoolean("decompiler.allow.text.buffer.to.string");
 
   private final String myLineSeparator = DecompilerContext.getNewLineSeparator();
   private final String myIndent = (String)DecompilerContext.getProperty(IFernflowerPreferences.INDENT_STRING);

--- a/test/org/jetbrains/java/decompiler/BulkDecompilationTest.java
+++ b/test/org/jetbrains/java/decompiler/BulkDecompilationTest.java
@@ -3,6 +3,7 @@ package org.jetbrains.java.decompiler;
 
 import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
 import org.jetbrains.java.decompiler.util.InterpreterUtil;
+import org.jetbrains.java.decompiler.util.TextBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,8 @@ public class BulkDecompilationTest {
     decompiler.decompileContext();
 
     assertFilesEqual(fixture.getTestDataDir().resolve("bulk"), fixture.getTargetDir());
+
+    TextBuffer.checkLeaks();
   }
 
   @Test
@@ -69,6 +72,8 @@ public class BulkDecompilationTest {
     unpack(fixture.getTargetDir().resolve(jarName), unpacked);
 
     assertFilesEqual(fixture.getTestDataDir().resolve(name), unpacked);
+
+    TextBuffer.checkLeaks();
   }
 
   private static void unpack(Path archive, Path targetDir) {

--- a/test/org/jetbrains/java/decompiler/BulkDecompilationTest.java
+++ b/test/org/jetbrains/java/decompiler/BulkDecompilationTest.java
@@ -41,9 +41,9 @@ public class BulkDecompilationTest {
     decompiler.addSource(classes.toFile());
     decompiler.decompileContext();
 
-    assertFilesEqual(fixture.getTestDataDir().resolve("bulk"), fixture.getTargetDir());
-
     TextBuffer.checkLeaks();
+
+    assertFilesEqual(fixture.getTestDataDir().resolve("bulk"), fixture.getTargetDir());
   }
 
   @Test
@@ -68,12 +68,12 @@ public class BulkDecompilationTest {
     decompiler.addSource(fixture.getTestDataDir().resolve(jarName).toFile());
     decompiler.decompileContext();
 
+    TextBuffer.checkLeaks();
+
     Path unpacked = fixture.getTempDir().resolve("unpacked");
     unpack(fixture.getTargetDir().resolve(jarName), unpacked);
 
     assertFilesEqual(fixture.getTestDataDir().resolve(name), unpacked);
-
-    TextBuffer.checkLeaks();
   }
 
   private static void unpack(Path archive, Path targetDir) {

--- a/test/org/jetbrains/java/decompiler/SingleClassesTestBase.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTestBase.java
@@ -16,6 +16,7 @@
 package org.jetbrains.java.decompiler;
 
 import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
+import org.jetbrains.java.decompiler.util.TextBuffer;
 import org.junit.jupiter.api.*;
 import org.opentest4j.AssertionFailedError;
 
@@ -214,6 +215,7 @@ public abstract class SingleClassesTestBase {
           }
         }
       }
+      TextBuffer.checkLeaks();
       fixture.tearDown();
     }
 

--- a/test/org/jetbrains/java/decompiler/SingleClassesTestBase.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTestBase.java
@@ -189,6 +189,8 @@ public abstract class SingleClassesTestBase {
 
       decompiler.decompileContext();
 
+      TextBuffer.checkLeaks();
+
       String testFileName = classFile.getFileName().toString();
       String testName = testFileName.substring(0, testFileName.length() - 6);
       Path decompiledFile = fixture.getTargetDir().resolve(testName + ".java");
@@ -215,7 +217,6 @@ public abstract class SingleClassesTestBase {
           }
         }
       }
-      TextBuffer.checkLeaks();
       fixture.tearDown();
     }
 


### PR DESCRIPTION
This PR turns the assumptions made by TextBuffer into actual assertions, enabled only in unit test mode for performance reasons. This introduces a fail-fast way to diagnose otherwise obscure bugs quickly and easily.