### PR TITLE
Add test to check for required casts from Object to Boxed primitives

### DIFF
--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -241,6 +241,8 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_8, "TestAssignmentInDoWhile");
     // TODO: Assignment of a = a is removed
     register(JAVA_8, "TestBooleanAssignment");
+    // TODO: Required casts are removed
+    register(JAVA_8, "TestCastObjectToPrimitive");
     register(JAVA_8, "TestCastPrimitiveToObject");
     register(JAVA_8, "TestDoWhileTrue");
     register(JAVA_8, "TestExtraClass");

--- a/testData/results/pkg/TestCastObjectToPrimitive.dec
+++ b/testData/results/pkg/TestCastObjectToPrimitive.dec
@@ -1,0 +1,17 @@
+package pkg;
+
+public class TestCastObjectToPrimitive {
+   static Object object1 = null;
+   boolean castObject = object1;
+   boolean negatedObject = !object1;
+   boolean booleanXor = object1 ^ object1;
+   boolean isObjectTrue = object1;
+   boolean isObjectFalse = !object1;
+   boolean isObject6 = object1 == 6;
+   boolean booleanOr = object1 || object1;
+   int integerXor = object1 ^ 5;
+   short shorXor = (short)(object1 ^ 58);
+   long longXor = 8L ^ object1;
+   boolean integerGe = object1 <= 48;
+}
+

--- a/testData/src/java8/pkg/TestCastObjectToPrimitive.java
+++ b/testData/src/java8/pkg/TestCastObjectToPrimitive.java
@@ -1,0 +1,18 @@
+package pkg;
+
+public class TestCastObjectToPrimitive {
+
+    static Object object1 = null;
+
+    boolean castObject = (Boolean) object1;
+    boolean negatedObject = !(Boolean) object1;
+    boolean booleanXor = (Boolean) object1 ^ (Boolean) object1;
+    boolean isObjectTrue = (Boolean) object1 == true;
+    boolean isObjectFalse = (Boolean) object1 == false;
+    boolean isObject6 = (Integer) object1 == 6;
+    boolean booleanOr = (Boolean) object1 || (Boolean) object1;
+    int integerXor = (Integer) object1 ^ 5;
+    short shorXor = (short) ((Short) object1 ^ 58);
+    long longXor = 8 ^ (Long) object1;
+    boolean integerGe = (Integer) object1 <= 48;
+}


### PR DESCRIPTION
While apparently there is a flag to make boxing/unboxing explicit, it isn't the default and this code does not recompile afterwards without it, so I believe that this is worthy of a test