### PR TITLE
Add `Implementation-Name: Quiltflower` to jar manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,8 @@ jar {
   manifest {
     attributes (
       'Multi-Release': 'true',
-      'Main-Class': 'org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler'
+      'Main-Class': 'org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler',
+      'Implementation-Name': "Quiltflower"
     )
   }
 }


### PR DESCRIPTION
This makes it super easy to know if a given decompiler jar is Quiltflower (as opposed to forge or vanilla fernflower)