### PR TITLE
Mostly fix Kotlin enum whens

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
@@ -41,7 +41,6 @@ public final class SwitchHelper {
     return ret;
   }
 
-  @SuppressWarnings("unchecked")
   private static boolean simplify(SwitchStatement switchStatement, StructMethod mt, RootStatement root) {
     SwitchStatement following = null;
     List<StatEdge> edges = switchStatement.getSuccessorEdges(StatEdge.TYPE_REGULAR);

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
@@ -12,14 +12,18 @@ import org.jetbrains.java.decompiler.modules.decompiler.stats.IfStatement;
 import org.jetbrains.java.decompiler.modules.decompiler.stats.RootStatement;
 import org.jetbrains.java.decompiler.modules.decompiler.stats.Statement;
 import org.jetbrains.java.decompiler.modules.decompiler.stats.SwitchStatement;
-import org.jetbrains.java.decompiler.struct.StructClass;
 import org.jetbrains.java.decompiler.struct.StructField;
 import org.jetbrains.java.decompiler.struct.StructMethod;
+import org.jetbrains.java.decompiler.util.Pair;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public final class SwitchHelper {
@@ -36,6 +40,7 @@ public final class SwitchHelper {
     return ret;
   }
 
+  @SuppressWarnings("unchecked")
   private static boolean simplify(SwitchStatement switchStatement, StructMethod mt, RootStatement root) {
     SwitchStatement following = null;
     List<StatEdge> edges = switchStatement.getSuccessorEdges(StatEdge.TYPE_REGULAR);
@@ -45,13 +50,15 @@ public final class SwitchHelper {
 
     SwitchHeadExprent switchHeadExprent = (SwitchHeadExprent)switchStatement.getHeadexprent();
     Exprent value = switchHeadExprent.getValue();
-    if (isEnumArray(value)) {
+    ArrayExprent array = getEnumArrayExprent(value, root);
+    if (array != null) {
       List<List<Exprent>> caseValues = switchStatement.getCaseValues();
       Map<Exprent, Exprent> mapping = new HashMap<>(caseValues.size());
-      ArrayExprent array = (ArrayExprent)value;
       if (array.getArray().type == Exprent.EXPRENT_FIELD) {
         FieldExprent arrayField = (FieldExprent) array.getArray();
         ClassesProcessor.ClassNode classNode = DecompilerContext.getClassProcessor().getMapRootClasses().get(arrayField.getClassname());
+        boolean[] shouldCheckLocalVariables = { true }; // single-element array for lambda restrictions
+        List<AssignmentExprent>[] fieldAssignments = new List[] { null }; // single-element array for lambda restrictions
         if (classNode != null) {
           ClassWrapper classWrapper = classNode.getWrapper();
           if (classWrapper != null) {
@@ -61,8 +68,39 @@ public final class SwitchHelper {
                 if (exprent instanceof AssignmentExprent) {
                   AssignmentExprent assignment = (AssignmentExprent) exprent;
                   Exprent left = assignment.getLeft();
-                  if (left.type == Exprent.EXPRENT_ARRAY && ((ArrayExprent) left).getArray().equals(arrayField)) {
-                    mapping.put(assignment.getRight(), ((InvocationExprent) ((ArrayExprent) left).getIndex()).getInstance());
+                  if (left.type == Exprent.EXPRENT_ARRAY) {
+                    Exprent assignmentArray = ((ArrayExprent) left).getArray();
+                    // If the assignment target is a field, we have the assignment we want.
+                    boolean targetsField = assignmentArray.equals(arrayField);
+
+                    // If the target is a local variable, this gets more complicated.
+                    // Kotlin (as mentioned above) creates its enum arrays by storing the array
+                    // in a local first, so we need to check if the variable is later uniquely
+                    // assigned to the enum array.
+                    if (!targetsField && assignmentArray instanceof VarExprent) {
+                      // Find all assignments that target the array field
+                      if (fieldAssignments[0] == null) {
+                        fieldAssignments[0] = getAssignmentsOfWithinOneStatement(wrapper.root, arrayField);
+                        if (fieldAssignments[0].size() > 1) {
+                          // assigned more than once => not what we're looking for
+                          shouldCheckLocalVariables[0] = false;
+                        }
+                      }
+
+                      // If we should check locals, check if the variable targets the field.
+                      if (shouldCheckLocalVariables[0]) {
+                        for (AssignmentExprent fieldAssignment : fieldAssignments[0]) {
+                          if (fieldAssignment.getRight().equals(assignmentArray)) {
+                            targetsField = true;
+                            break;
+                          }
+                        }
+                      }
+                    }
+
+                    if (targetsField) {
+                      mapping.put(assignment.getRight(), ((InvocationExprent) ((ArrayExprent) left).getIndex()).getInstance());
+                    }
                   }
                 }
                 return 0;
@@ -120,6 +158,23 @@ public final class SwitchHelper {
       caseValues.clear();
       caseValues.addAll(realCaseValues);
       switchHeadExprent.replaceExprent(value, ((InvocationExprent)array.getIndex()).getInstance().copy());
+
+      // If we replaced the only use of the local var, the variable should be removed altogether.
+      if (value instanceof VarExprent) {
+        VarExprent var = (VarExprent) value;
+        List<Pair<Statement, Exprent>> references = new ArrayList<>();
+        findExprents(root, Exprent.class, var::isVarReferenced, false, (stat, expr) -> references.add(Pair.of(stat, expr)));
+
+        // If we only have one reference...
+        if (references.size() == 1) {
+          // ...and if it's just an assignment, remove it.
+          Pair<Statement, Exprent> ref = references.get(0);
+          if (ref.b instanceof AssignmentExprent && ((AssignmentExprent) ref.b).getLeft().equals(value)) {
+            ref.a.getExprents().remove(ref.b);
+          }
+        }
+      }
+
       return true;
     }
     else if (isSwitchOnString(switchStatement, following)) {
@@ -232,6 +287,87 @@ public final class SwitchHelper {
       }
     }
     return false;
+  }
+
+  /**
+   * Gets the enum array exprent (or null if not found) corresponding to
+   * the switch head. If the switch head itself is an enum array, returns the head.
+   * If it's a variable only assigned to an enum array, returns that array.
+   */
+  private static ArrayExprent getEnumArrayExprent(Exprent switchHead, RootStatement root) {
+    Exprent candidate = switchHead;
+
+    if (switchHead instanceof VarExprent) {
+      // Check for switches with intermediary assignment of enum array index
+      // This happens with Kotlin when expressions on enums.
+      VarExprent var = (VarExprent) switchHead;
+
+      if (!"I".equals(var.getVarType().toString())) {
+        // Enum array index must be int
+        return null;
+      }
+
+      List<AssignmentExprent> assignments = getAssignmentsOfWithinOneStatement(root, var);
+
+      if (!assignments.isEmpty()) {
+        if (assignments.size() == 1) {
+          AssignmentExprent assignment = assignments.get(0);
+          candidate = assignment.getRight();
+        } else {
+          // more than 1 assignment to variable => can't be what we're looking for
+          return null;
+        }
+      }
+    }
+
+    return isEnumArray(candidate) ? (ArrayExprent) candidate : null;
+  }
+
+  /**
+   * Recursively searches for assignments of the target that happen within one statement.
+   * This is done as a list because the intended outcomes of the "1 found" (unique) and "2+ found" (non-unique) cases
+   * are different. (But we don't need to have all the assignments within the root stat
+   * because the non-unique case is a failure.)
+   */
+  private static List<AssignmentExprent> getAssignmentsOfWithinOneStatement(Statement start, Exprent target) {
+    List<AssignmentExprent> exprents = new ArrayList<>();
+    findExprents(start, AssignmentExprent.class, assignment -> assignment.getLeft().equals(target), true, (stat, expr) -> exprents.add(expr));
+    return exprents;
+  }
+
+  /**
+   * Recursively searches one statement for matching exprents.
+   *
+   * @param start       the statement to search
+   * @param exprClass   the wanted exprent type
+   * @param predicate   a predicate for filtering the exprents
+   * @param onlyOneStat if true, will return eagerly after the first matching statement
+   * @param consumer    the consumer that receives the exprents and their parent statements
+   */
+  @SuppressWarnings("unchecked")
+  private static <T extends Exprent> void findExprents(Statement start, Class<? extends T> exprClass, Predicate<T> predicate, boolean onlyOneStat, BiConsumer<Statement, T> consumer) {
+    Queue<Statement> statQueue = new ArrayDeque<>();
+    statQueue.offer(start);
+
+    while (!statQueue.isEmpty()) {
+      Statement stat = statQueue.remove();
+      statQueue.addAll(stat.getStats());
+
+      if (stat.getExprents() != null) {
+        boolean foundAny = false;
+
+        for (Exprent expr : stat.getExprents()) {
+          if (exprClass.isInstance(expr) && predicate.test((T) expr)) {
+            consumer.accept(stat, (T) expr);
+            foundAny = true;
+          }
+        }
+
+        if (onlyOneStat && foundAny) {
+          break;
+        }
+      }
+    }
   }
 
   /**

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
@@ -35,7 +35,6 @@ public final class SwitchHelper {
     return ret;
   }
 
-  @SuppressWarnings("unchecked")
   private static boolean simplify(SwitchStatement switchStatement, StructMethod mt, RootStatement root) {
     SwitchStatement following = null;
     List<StatEdge> edges = switchStatement.getSuccessorEdges(StatEdge.TYPE_REGULAR);

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -487,7 +487,6 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_8, "TestArrayFieldAccess1");
     register(JAVA_8, "TestPPMMMath");
     register(JASM, "TestSwapException");
-    // TODO: kotlin when expressions on enums should resugar to java enum switches
     register(KOTLIN, "TestKotlinEnumWhen");
   }
 

--- a/testData/results/pkg/TestKotlinEnumWhen.dec
+++ b/testData/results/pkg/TestKotlinEnumWhen.dec
@@ -9,8 +9,8 @@ import kotlin.jvm.internal.Intrinsics;
    mv = {1, 5, 1},
    k = 1,
    xi = 48,
-   d1 = {"\u0000\u0014\n\u0002\u0018\u0002\n\u0002\u0010\u0010\n\u0002\b\u0002\n\u0002\u0010\u0002\n\u0002\b\u0007\b\u0086\u0001\u0018\u00002\b\u0012\u0004\u0012\u00020\u00000\u0001B\u0007\b\u0002¢\u0006\u0002\u0010\u0002J\u0006\u0010\u0003\u001a\u00020\u0004J\u0006\u0010\u0005\u001a\u00020\u0004J\u0006\u0010\u0006\u001a\u00020\u0004J\u0006\u0010\u0007\u001a\u00020\u0004j\u0002\b\bj\u0002\b\tj\u0002\b\n¨\u0006\u000b"},
-   d2 = {"Lpkg/TestKotlinEnumWhen;", "", "(Ljava/lang/String;I)V", "testAnotherEnum", "", "testConsecutive", "testExpression", "testStatement", "FIRST", "SECOND", "THIRD", "quiltflower_testDataKotlin"}
+   d1 = {"\u0000\u0014\n\u0002\u0018\u0002\n\u0002\u0010\u0010\n\u0002\b\u0002\n\u0002\u0010\u0002\n\u0002\b\b\b\u0086\u0001\u0018\u00002\b\u0012\u0004\u0012\u00020\u00000\u0001B\u0007\b\u0002¢\u0006\u0002\u0010\u0002J\u0006\u0010\u0003\u001a\u00020\u0004J\u0006\u0010\u0005\u001a\u00020\u0004J\u0006\u0010\u0006\u001a\u00020\u0004J\u0006\u0010\u0007\u001a\u00020\u0004J\u0006\u0010\b\u001a\u00020\u0004j\u0002\b\tj\u0002\b\nj\u0002\b\u000b¨\u0006\f"},
+   d2 = {"Lpkg/TestKotlinEnumWhen;", "", "(Ljava/lang/String;I)V", "testAnotherEnum", "", "testConsecutive", "testConsecutiveMixed", "testExpression", "testStatement", "FIRST", "SECOND", "THIRD", "quiltflower_testDataKotlin"}
 )
 public enum TestKotlinEnumWhen {
    FIRST,
@@ -116,8 +116,50 @@ public enum TestKotlinEnumWhen {
 
    }// 47
 
+   public final void testConsecutiveMixed() {
+      DeprecationLevel level = testConsecutiveMixed$getLevel-0();// 53
+      switch(level) {
+      case WARNING:
+         String var7 = Intrinsics.stringPlus("warning ", level);// 54
+         boolean var12 = false;
+         System.out.println(var7);
+         break;
+      case ERROR:
+         String var6 = Intrinsics.stringPlus("error ", level);// 55
+         boolean var11 = false;
+         System.out.println(var6);
+         break;
+      case HIDDEN:
+         String var3 = Intrinsics.stringPlus("hidden ", level);// 56
+         boolean var4 = false;
+         System.out.println(var3);
+      }
+
+      switch(this) {// 59
+      case FIRST:
+         String var10 = "first!";// 60
+         boolean var15 = false;
+         System.out.println(var10);
+         break;
+      case SECOND:
+         String var9 = "second!";// 61
+         boolean var14 = false;
+         System.out.println(var9);
+         break;
+      case THIRD:
+         String var8 = "third!";// 62
+         boolean var13 = false;
+         System.out.println(var8);
+      }
+
+   }// 64
+
    private static final DeprecationLevel testAnotherEnum$getLevel() {
       throw new Exception();// 26
+   }
+
+   private static final DeprecationLevel testConsecutiveMixed$getLevel_0/* $FF was: testConsecutiveMixed$getLevel-0*/() {
+      throw new Exception();// 51
    }
 }
 
@@ -340,8 +382,114 @@ class 'pkg/TestKotlinEnumWhen' {
       a9      116
    }
 
+   method 'testConsecutiveMixed ()V' {
+      0      119
+      1      119
+      2      119
+      3      119
+      7      120
+      e      120
+      28      122
+      29      122
+      2a      122
+      2b      122
+      2c      122
+      2d      122
+      2e      122
+      2f      123
+      30      123
+      31      123
+      32      124
+      33      124
+      34      124
+      35      124
+      36      124
+      37      124
+      38      124
+      39      125
+      3c      127
+      3d      127
+      3e      127
+      3f      127
+      40      127
+      41      127
+      42      127
+      43      128
+      44      128
+      45      128
+      46      129
+      47      129
+      48      129
+      49      129
+      4a      129
+      4b      129
+      4c      129
+      4d      130
+      50      132
+      51      132
+      52      132
+      53      132
+      54      132
+      55      132
+      56      132
+      57      133
+      58      133
+      59      133
+      5a      134
+      5b      134
+      5c      134
+      5d      134
+      5e      134
+      61      137
+      6d      137
+      88      139
+      89      139
+      8a      139
+      8b      140
+      8c      140
+      8d      140
+      8e      141
+      8f      141
+      90      141
+      91      141
+      92      141
+      93      141
+      94      141
+      95      142
+      98      144
+      99      144
+      9a      144
+      9b      145
+      9c      145
+      9d      145
+      9e      146
+      9f      146
+      a0      146
+      a1      146
+      a2      146
+      a3      146
+      a4      146
+      a5      147
+      a8      149
+      a9      149
+      aa      149
+      ab      150
+      ac      150
+      ad      150
+      ae      151
+      af      151
+      b0      151
+      b1      151
+      b2      151
+      b5      154
+   }
+
    method 'testAnotherEnum$getLevel ()Lkotlin/DeprecationLevel;' {
-      7      119
+      7      157
+   }
+
+   method 'testConsecutiveMixed$getLevel-0 ()Lkotlin/DeprecationLevel;' {
+      7      161
    }
 }
 
@@ -357,7 +505,7 @@ Lines mapping:
 18 <-> 47
 19 <-> 50
 22 <-> 59
-26 <-> 120
+26 <-> 158
 28 <-> 62
 29 <-> 65
 30 <-> 70
@@ -372,3 +520,13 @@ Lines mapping:
 44 <-> 107
 45 <-> 112
 47 <-> 117
+51 <-> 162
+53 <-> 120
+54 <-> 123
+55 <-> 128
+56 <-> 133
+59 <-> 138
+60 <-> 140
+61 <-> 145
+62 <-> 150
+64 <-> 155

--- a/testData/results/pkg/TestKotlinEnumWhen.dec
+++ b/testData/results/pkg/TestKotlinEnumWhen.dec
@@ -9,8 +9,8 @@ import kotlin.jvm.internal.Intrinsics;
    mv = {1, 5, 1},
    k = 1,
    xi = 48,
-   d1 = {"\u0000\u0014\n\u0002\u0018\u0002\n\u0002\u0010\u0010\n\u0002\b\u0002\n\u0002\u0010\u0002\n\u0002\b\u0006\b\u0086\u0001\u0018\u00002\b\u0012\u0004\u0012\u00020\u00000\u0001B\u0007\b\u0002¢\u0006\u0002\u0010\u0002J\u0006\u0010\u0003\u001a\u00020\u0004J\u0006\u0010\u0005\u001a\u00020\u0004J\u0006\u0010\u0006\u001a\u00020\u0004j\u0002\b\u0007j\u0002\b\bj\u0002\b\t¨\u0006\n"},
-   d2 = {"Lpkg/TestKotlinEnumWhen;", "", "(Ljava/lang/String;I)V", "testAnotherEnum", "", "testExpression", "testStatement", "FIRST", "SECOND", "THIRD", "quiltflower_testDataKotlin"}
+   d1 = {"\u0000\u0014\n\u0002\u0018\u0002\n\u0002\u0010\u0010\n\u0002\b\u0002\n\u0002\u0010\u0002\n\u0002\b\u0007\b\u0086\u0001\u0018\u00002\b\u0012\u0004\u0012\u00020\u00000\u0001B\u0007\b\u0002¢\u0006\u0002\u0010\u0002J\u0006\u0010\u0003\u001a\u00020\u0004J\u0006\u0010\u0005\u001a\u00020\u0004J\u0006\u0010\u0006\u001a\u00020\u0004J\u0006\u0010\u0007\u001a\u00020\u0004j\u0002\b\bj\u0002\b\tj\u0002\b\n¨\u0006\u000b"},
+   d2 = {"Lpkg/TestKotlinEnumWhen;", "", "(Ljava/lang/String;I)V", "testAnotherEnum", "", "testConsecutive", "testExpression", "testStatement", "FIRST", "SECOND", "THIRD", "quiltflower_testDataKotlin"}
 )
 public enum TestKotlinEnumWhen {
    FIRST,
@@ -18,19 +18,18 @@ public enum TestKotlinEnumWhen {
    THIRD;
 
    public final void testStatement() {
-      int var2 = TestKotlinEnumWhen.WhenMappings.$EnumSwitchMapping$0[this.ordinal()];// 7
-      switch(var2) {
-      case 1:
+      switch(this) {// 7
+      case WARNING:
          String var6 = "first!";// 8
          boolean var8 = false;
          System.out.println(var6);
          break;
-      case 2:
+      case ERROR:
          String var5 = "second!";// 9
          boolean var7 = false;
          System.out.println(var5);
          break;
-      case 3:
+      case HIDDEN:
          String var3 = "third!";// 10
          boolean var4 = false;
          System.out.println(var3);
@@ -39,16 +38,15 @@ public enum TestKotlinEnumWhen {
    }// 12
 
    public final void testExpression() {
-      int var2 = TestKotlinEnumWhen.WhenMappings.$EnumSwitchMapping$0[this.ordinal()];// 16
       String var10000;
-      switch(var2) {
-      case 1:
+      switch(this) {// 16
+      case WARNING:
          var10000 = "first!";// 17
          break;
-      case 2:
+      case ERROR:
          var10000 = "second!";// 18
          break;
-      case 3:
+      case HIDDEN:
          var10000 = "third!";// 19
          break;
       default:
@@ -56,31 +54,67 @@ public enum TestKotlinEnumWhen {
       }
 
       String var1 = var10000;
-      var2 = 0;// 15
+      boolean var3 = false;// 15
       System.out.println(var1);
    }// 22
 
    public final void testAnotherEnum() {
       DeprecationLevel level = testAnotherEnum$getLevel();// 28
-      int var2 = TestKotlinEnumWhen.WhenMappings.$EnumSwitchMapping$1[level.ordinal()];
-      switch(var2) {
-      case 1:
+      switch(level) {
+      case WARNING:
          String var6 = Intrinsics.stringPlus("warning ", level);// 29
          boolean var8 = false;
          System.out.println(var6);
          break;
-      case 2:
+      case ERROR:
          String var5 = Intrinsics.stringPlus("error ", level);// 30
          boolean var7 = false;
          System.out.println(var5);
          break;
-      case 3:
+      case HIDDEN:
          String var3 = Intrinsics.stringPlus("hidden ", level);// 31
          boolean var4 = false;
          System.out.println(var3);
       }
 
    }// 33
+
+   public final void testConsecutive() {
+      switch(this) {// 36
+      case WARNING:
+         String var7 = "first!";// 37
+         boolean var12 = false;
+         System.out.println(var7);
+         break;
+      case ERROR:
+         String var6 = "second!";// 38
+         boolean var11 = false;
+         System.out.println(var6);
+         break;
+      case HIDDEN:
+         String var3 = "third!";// 39
+         boolean var4 = false;
+         System.out.println(var3);
+      }
+
+      switch(this) {// 42
+      case WARNING:
+         String var10 = "first, again!";// 43
+         boolean var15 = false;
+         System.out.println(var10);
+         break;
+      case ERROR:
+         String var9 = "second, again!";// 44
+         boolean var14 = false;
+         System.out.println(var9);
+         break;
+      case HIDDEN:
+         String var8 = "third, again!";// 45
+         boolean var13 = false;
+         System.out.println(var8);
+      }
+
+   }// 47
 
    private static final DeprecationLevel testAnotherEnum$getLevel() {
       throw new Exception();// 26
@@ -90,183 +124,251 @@ public enum TestKotlinEnumWhen {
 class 'pkg/TestKotlinEnumWhen' {
    method 'testStatement ()V' {
       0      20
-      2      20
-      3      20
-      4      20
-      6      20
-      7      20
-      8      20
-      9      20
-      a      20
-      b      21
-      c      21
-      28      23
-      29      23
-      2a      23
-      2b      24
-      2c      24
-      2d      24
-      2e      25
-      2f      25
-      30      25
-      31      25
-      32      25
-      33      25
-      34      25
-      35      26
-      38      28
-      39      28
-      3a      28
-      3b      29
-      3c      29
-      3d      29
-      3e      30
-      3f      30
-      40      30
-      41      30
-      42      30
-      43      30
-      44      30
-      45      31
-      48      33
-      49      33
-      4a      33
-      4b      34
-      4c      34
-      4d      34
-      4e      35
-      4f      35
-      50      35
-      51      35
-      52      35
-      55      38
+      c      20
+      28      22
+      29      22
+      2a      22
+      2b      23
+      2c      23
+      2d      23
+      2e      24
+      2f      24
+      30      24
+      31      24
+      32      24
+      33      24
+      34      24
+      35      25
+      38      27
+      39      27
+      3a      27
+      3b      28
+      3c      28
+      3d      28
+      3e      29
+      3f      29
+      40      29
+      41      29
+      42      29
+      43      29
+      44      29
+      45      30
+      48      32
+      49      32
+      4a      32
+      4b      33
+      4c      33
+      4d      33
+      4e      34
+      4f      34
+      50      34
+      51      34
+      52      34
+      55      37
    }
 
    method 'testExpression ()V' {
       0      41
-      2      41
-      3      41
-      4      41
-      6      41
-      7      41
-      8      41
-      9      41
-      a      41
-      b      43
-      c      43
-      28      45
-      29      45
-      2a      46
-      2d      48
-      2e      48
-      2f      49
-      32      51
-      33      51
-      34      52
-      3e      54
-      3f      57
-      40      58
-      41      58
-      42      59
-      43      59
-      44      59
-      45      59
-      46      59
-      47      59
-      48      59
-      49      60
+      c      41
+      28      43
+      29      43
+      2a      44
+      2d      46
+      2e      46
+      2f      47
+      32      49
+      33      49
+      34      50
+      3e      52
+      3f      55
+      40      56
+      41      56
+      42      57
+      43      57
+      44      57
+      45      57
+      46      57
+      47      57
+      48      57
+      49      58
    }
 
    method 'testAnotherEnum ()V' {
-      0      63
-      1      63
-      2      63
-      3      63
-      4      64
-      5      64
-      6      64
-      7      64
-      8      64
-      9      64
-      a      64
-      b      64
-      c      64
-      d      65
-      e      65
-      28      67
-      29      67
-      2a      67
-      2b      67
-      2c      67
-      2d      67
-      2e      67
-      2f      68
-      30      68
-      31      68
-      32      69
-      33      69
-      34      69
-      35      69
-      36      69
-      37      69
-      38      69
-      39      70
-      3c      72
-      3d      72
-      3e      72
-      3f      72
-      40      72
-      41      72
-      42      72
-      43      73
-      44      73
-      45      73
-      46      74
-      47      74
-      48      74
-      49      74
-      4a      74
-      4b      74
-      4c      74
-      4d      75
-      50      77
-      51      77
-      52      77
-      53      77
-      54      77
-      55      77
-      56      77
-      57      78
-      58      78
-      59      78
-      5a      79
-      5b      79
-      5c      79
-      5d      79
-      5e      79
-      61      82
+      0      61
+      1      61
+      2      61
+      3      61
+      7      62
+      e      62
+      28      64
+      29      64
+      2a      64
+      2b      64
+      2c      64
+      2d      64
+      2e      64
+      2f      65
+      30      65
+      31      65
+      32      66
+      33      66
+      34      66
+      35      66
+      36      66
+      37      66
+      38      66
+      39      67
+      3c      69
+      3d      69
+      3e      69
+      3f      69
+      40      69
+      41      69
+      42      69
+      43      70
+      44      70
+      45      70
+      46      71
+      47      71
+      48      71
+      49      71
+      4a      71
+      4b      71
+      4c      71
+      4d      72
+      50      74
+      51      74
+      52      74
+      53      74
+      54      74
+      55      74
+      56      74
+      57      75
+      58      75
+      59      75
+      5a      76
+      5b      76
+      5c      76
+      5d      76
+      5e      76
+      61      79
+   }
+
+   method 'testConsecutive ()V' {
+      0      82
+      c      82
+      28      84
+      29      84
+      2a      84
+      2b      85
+      2c      85
+      2d      85
+      2e      86
+      2f      86
+      30      86
+      31      86
+      32      86
+      33      86
+      34      86
+      35      87
+      38      89
+      39      89
+      3a      89
+      3b      90
+      3c      90
+      3d      90
+      3e      91
+      3f      91
+      40      91
+      41      91
+      42      91
+      43      91
+      44      91
+      45      92
+      48      94
+      49      94
+      4a      94
+      4b      95
+      4c      95
+      4d      95
+      4e      96
+      4f      96
+      50      96
+      51      96
+      52      96
+      55      99
+      61      99
+      7c      101
+      7d      101
+      7e      101
+      7f      102
+      80      102
+      81      102
+      82      103
+      83      103
+      84      103
+      85      103
+      86      103
+      87      103
+      88      103
+      89      104
+      8c      106
+      8d      106
+      8e      106
+      8f      107
+      90      107
+      91      107
+      92      108
+      93      108
+      94      108
+      95      108
+      96      108
+      97      108
+      98      108
+      99      109
+      9c      111
+      9d      111
+      9e      111
+      9f      112
+      a0      112
+      a1      112
+      a2      113
+      a3      113
+      a4      113
+      a5      113
+      a6      113
+      a9      116
    }
 
    method 'testAnotherEnum$getLevel ()Lkotlin/DeprecationLevel;' {
-      7      85
+      7      119
    }
 }
 
 Lines mapping:
 7 <-> 21
-8 <-> 24
-9 <-> 29
-10 <-> 34
-12 <-> 39
-15 <-> 59
+8 <-> 23
+9 <-> 28
+10 <-> 33
+12 <-> 38
+15 <-> 57
 16 <-> 42
-17 <-> 46
-18 <-> 49
-19 <-> 52
-22 <-> 61
-26 <-> 86
-28 <-> 64
-29 <-> 68
-30 <-> 73
-31 <-> 78
-33 <-> 83
+17 <-> 44
+18 <-> 47
+19 <-> 50
+22 <-> 59
+26 <-> 120
+28 <-> 62
+29 <-> 65
+30 <-> 70
+31 <-> 75
+33 <-> 80
+36 <-> 83
+37 <-> 85
+38 <-> 90
+39 <-> 95
+42 <-> 100
+43 <-> 102
+44 <-> 107
+45 <-> 112
+47 <-> 117

--- a/testData/results/pkg/TestKotlinEnumWhen.dec
+++ b/testData/results/pkg/TestKotlinEnumWhen.dec
@@ -19,17 +19,17 @@ public enum TestKotlinEnumWhen {
 
    public final void testStatement() {
       switch(this) {// 7
-      case WARNING:
+      case FIRST:
          String var6 = "first!";// 8
          boolean var8 = false;
          System.out.println(var6);
          break;
-      case ERROR:
+      case SECOND:
          String var5 = "second!";// 9
          boolean var7 = false;
          System.out.println(var5);
          break;
-      case HIDDEN:
+      case THIRD:
          String var3 = "third!";// 10
          boolean var4 = false;
          System.out.println(var3);
@@ -40,13 +40,13 @@ public enum TestKotlinEnumWhen {
    public final void testExpression() {
       String var10000;
       switch(this) {// 16
-      case WARNING:
+      case FIRST:
          var10000 = "first!";// 17
          break;
-      case ERROR:
+      case SECOND:
          var10000 = "second!";// 18
          break;
-      case HIDDEN:
+      case THIRD:
          var10000 = "third!";// 19
          break;
       default:
@@ -81,34 +81,34 @@ public enum TestKotlinEnumWhen {
 
    public final void testConsecutive() {
       switch(this) {// 36
-      case WARNING:
+      case FIRST:
          String var7 = "first!";// 37
          boolean var12 = false;
          System.out.println(var7);
          break;
-      case ERROR:
+      case SECOND:
          String var6 = "second!";// 38
          boolean var11 = false;
          System.out.println(var6);
          break;
-      case HIDDEN:
+      case THIRD:
          String var3 = "third!";// 39
          boolean var4 = false;
          System.out.println(var3);
       }
 
       switch(this) {// 42
-      case WARNING:
+      case FIRST:
          String var10 = "first, again!";// 43
          boolean var15 = false;
          System.out.println(var10);
          break;
-      case ERROR:
+      case SECOND:
          String var9 = "second, again!";// 44
          boolean var14 = false;
          System.out.println(var9);
          break;
-      case HIDDEN:
+      case THIRD:
          String var8 = "third, again!";// 45
          boolean var13 = false;
          System.out.println(var8);

--- a/testData/src/kt/pkg/TestKotlinEnumWhen.kt
+++ b/testData/src/kt/pkg/TestKotlinEnumWhen.kt
@@ -45,4 +45,21 @@ enum class TestKotlinEnumWhen {
       THIRD -> println("third, again!")
     }
   }
+
+  fun testConsecutiveMixed() {
+    // Using a nested function prevents kotlinc from inlining the exception
+    fun getLevel(): DeprecationLevel = throw Exception()
+
+    when (val level = getLevel()) {
+      DeprecationLevel.WARNING -> println("warning $level")
+      DeprecationLevel.ERROR -> println("error $level")
+      DeprecationLevel.HIDDEN -> println("hidden $level")
+    }
+
+    when (this) {
+      FIRST -> println("first!")
+      SECOND -> println("second!")
+      THIRD -> println("third!")
+    }
+  }
 }

--- a/testData/src/kt/pkg/TestKotlinEnumWhen.kt
+++ b/testData/src/kt/pkg/TestKotlinEnumWhen.kt
@@ -31,4 +31,18 @@ enum class TestKotlinEnumWhen {
       DeprecationLevel.HIDDEN -> println("hidden $level")
     }
   }
+
+  fun testConsecutive() {
+    when (this) {
+      FIRST -> println("first!")
+      SECOND -> println("second!")
+      THIRD -> println("third!")
+    }
+
+    when (this) {
+      FIRST -> println("first, again!")
+      SECOND -> println("second, again!")
+      THIRD -> println("third, again!")
+    }
+  }
 }


### PR DESCRIPTION
This still leaves the weird `boolean varXYZ = false;` (or `ICONST_0`) assignments laying around - not sure what the Kotlin compiler is trying to achieve there.

The `findExprents` method is also cursedly general but shouldn't be too much of a perf bottleneck because I avoided streams (the original iteration created streams and `Pair<Statement, Exprent)` even when not needed)

- [x] fix all enums pulling the value names of a single enum