### PR TITLE
Update example usage to mention quiltflower.jar instead of fernflower

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
+++ b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
@@ -62,8 +62,8 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
 
     if (args.length < 2) {
       System.out.println(
-        "Usage: java -jar fernflower.jar [-<option>=<value>]* [<source>]+ <destination>\n" +
-        "Example: java -jar fernflower.jar -dgs=true c:\\my\\source\\ c:\\my.jar d:\\decompiled\\");
+        "Usage: java -jar quiltflower.jar [-<option>=<value>]* [<source>]+ <destination>\n" +
+        "Example: java -jar quiltflower.jar -dgs=true c:\\my\\source\\ c:\\my.jar d:\\decompiled\\");
       return;
     }
 


### PR DESCRIPTION
As pointed out by [msx on Reddit](https://www.reddit.com/r/java/comments/ue8u59/new_open_source_java_decompiler/i6n53q4).