### PR TITLE
Fix inacessible digraph nodes

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
+++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
@@ -11,6 +11,8 @@ import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
 import org.jetbrains.java.decompiler.modules.code.DeadCodeHelper;
 import org.jetbrains.java.decompiler.modules.decompiler.*;
 import org.jetbrains.java.decompiler.modules.decompiler.deobfuscator.ExceptionDeobfuscator;
+import org.jetbrains.java.decompiler.modules.decompiler.sforms.DirectGraph;
+import org.jetbrains.java.decompiler.modules.decompiler.sforms.FlattenStatementsHelper;
 import org.jetbrains.java.decompiler.modules.decompiler.stats.RootStatement;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.VarProcessor;
 import org.jetbrains.java.decompiler.struct.StructClass;
@@ -384,6 +386,12 @@ public class MethodProcessorRunnable implements Runnable {
     }
 
     DotExporter.toDotFile(root, mt, "finalStatement");
+
+    if (DotExporter.DUMP_DOTS) {
+      FlattenStatementsHelper flatten = new FlattenStatementsHelper();
+      DirectGraph digraph = flatten.buildDirectGraph(root);
+      DotExporter.toDotFile(digraph, mt, "finalStatementDigraph");
+    }
 
     // Debug print the decompile record
     DotExporter.toDotFile(decompileRecord, mt, "decompileRecord", false);

--- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
+++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
@@ -144,10 +144,12 @@ public class MethodProcessorRunnable implements Runnable {
     while (fProc.iterateGraph(cl, mt, root, graph)) {
       finallyProcessed++;
       RootStatement oldRoot = root;
-      decompileRecord.add("ProcessFinally_old" + finallyProcessed, root);
-      DotExporter.toDotFile(graph, mt, "cfgProcessFinally" + finallyProcessed, true);
+      decompileRecord.add("ProcessFinallyOld_" + finallyProcessed, root);
+      DotExporter.toDotFile(graph, mt, "cfgProcessFinally_" + finallyProcessed, true);
+
       root = DomHelper.parseGraph(graph, mt);
       root.addComments(oldRoot);
+
       decompileRecord.add("ProcessFinally_" + finallyProcessed, root);
 
       debugCurrentCFG.set(graph);

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExitHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExitHelper.java
@@ -7,8 +7,11 @@ import org.jetbrains.java.decompiler.main.collectors.CounterContainer;
 import org.jetbrains.java.decompiler.modules.decompiler.exps.ConstExprent;
 import org.jetbrains.java.decompiler.modules.decompiler.exps.ExitExprent;
 import org.jetbrains.java.decompiler.modules.decompiler.exps.Exprent;
+import org.jetbrains.java.decompiler.modules.decompiler.sforms.DirectGraph;
+import org.jetbrains.java.decompiler.modules.decompiler.sforms.FlattenStatementsHelper;
 import org.jetbrains.java.decompiler.modules.decompiler.stats.*;
 import org.jetbrains.java.decompiler.struct.gen.MethodDescriptor;
+import org.jetbrains.java.decompiler.util.DotExporter;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/ValidationHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ValidationHelper.java
@@ -301,7 +301,7 @@ public final class ValidationHelper {
       if (!inaccessibleNodes.isEmpty()) {
         throw new IllegalStateException("Inaccessible nodes: " + inaccessibleNodes);
       }
-    } catch (Throwable e){
+    } catch (Throwable e) {
       DotExporter.errorToDotFile(graph, root.mt, "erroring_dgraph");
       throw e;
     }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
@@ -458,6 +458,9 @@ public class FlattenStatementsHelper {
                 }
               } else { // finally protected try statement
                 if (!catchall.containsStatementStrict(destination)) {
+
+                  // FIXME: this is a hack, the edges need to be more properly defined from the finally handler to it's destination
+                  //  Otherwise problems can occur where variable usage scopes aren't correct!
                   // Edge from finally handler head to destination
                   listEdges.add(new Edge(sourcenode.id, destination.id, edgetype));
 

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
@@ -139,31 +139,6 @@ public class FlattenStatementsHelper {
                   addEdgeIfPossible(predEdge.getSource().getBasichead().id, stat);
                 }
               }
-            } else if (!hasAnyEdgeTo(listEdges, stat)) {
-              // No edges exist towards this block
-              basicPreds = stat.getPredecessorEdges(StatEdge.TYPE_REGULAR);
-
-              // Find predecessor
-              if (basicPreds.size() == 1) {
-                StatEdge predEdge = basicPreds.get(0);
-
-                Statement source = predEdge.getSource();
-
-                if (source.type == Statement.TYPE_DO) {
-                  if (((DoStatement)source).getLooptype() ==  DoStatement.LOOP_DO) {
-                    // Infinite loop should not have a regular successor
-                    List<StatEdge> predEdges = source.getPredecessorEdges(StatEdge.TYPE_REGULAR);
-
-                    if (predEdges.isEmpty()) {
-                      for (StatEdge edge : source.getLabelEdges()) {
-                        if (edge.getType() == StatEdge.TYPE_BREAK) {
-                          addEdgeIfPossible(edge.getSource().getBasichead().id, stat);
-                        }
-                      }
-                    }
-                  }
-                }
-              }
             }
 
             break;

--- a/src/org/jetbrains/java/decompiler/util/DotExporter.java
+++ b/src/org/jetbrains/java/decompiler/util/DotExporter.java
@@ -125,10 +125,11 @@ public class DotExporter {
         buffer.append(src + "->" + destId + " [color=orange,label=\"Label Edge (" + data + ") (Contained by " + st.id + ")\"];\r\n");
       }
 
-      for (Statement neighbour : st.getNeighbours(Statement.STATEDGE_ALL, Statement.DIRECTION_FORWARD)) {
-        String destId = neighbour.id + (neighbour.getSuccessorEdges(StatEdge.TYPE_EXCEPTION).isEmpty()?"":"000000");
-        buffer.append(sourceId + "->" + destId + " [arrowhead=tee,color=purple];\r\n");
-      }
+      // Neighbor set is redundant
+//      for (Statement neighbour : st.getNeighbours(Statement.STATEDGE_ALL, Statement.DIRECTION_FORWARD)) {
+//        String destId = neighbour.id + (neighbour.getSuccessorEdges(StatEdge.TYPE_EXCEPTION).isEmpty()?"":"000000");
+//        buffer.append(sourceId + "->" + destId + " [arrowhead=tee,color=purple];\r\n");
+//      }
 
       for(StatEdge edge : st.getPredecessorEdges(Statement.STATEDGE_ALL)) {
         String destId = edge.getSource().id + (edge.getSource().getSuccessorEdges(StatEdge.TYPE_EXCEPTION).isEmpty() ? "" : "000000");

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -456,6 +456,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     // TODO: test9&10- for loop not created, loop extractor needs another pass
     register(JAVA_8, "TestSwitchLoop");
     register(JAVA_8, "TestSwitchFinally");
+    // TODO: test3 has wrong edge semantics for break and continue
     register(JAVA_8, "TestLoopFinally");
     // TODO: local classes not being put in the right spots
     register(JAVA_8, "TestLocalClassesSwitch"); // Adapted from CFR

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -457,6 +457,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_8, "TestSwitchLoop");
     register(JAVA_8, "TestSwitchFinally");
     // TODO: test3 has wrong edge semantics for break and continue
+    // TODO: test5 variable usage in finally block is incorrect
     register(JAVA_8, "TestLoopFinally");
     // TODO: local classes not being put in the right spots
     register(JAVA_8, "TestLocalClassesSwitch"); // Adapted from CFR

--- a/testData/results/pkg/TestClassLoop.dec
+++ b/testData/results/pkg/TestClassLoop.dec
@@ -21,57 +21,71 @@ public class TestClassLoop {
       }
    }
 
-   public static void testFinallyContinue() {
+   public static void testCatch() {
       boolean a = Math.random() > 0.0;// 45
+
+      while(true) {
+         try {
+            if (!a) {// 49
+               return;// 50
+            }
+         } catch (Exception var2) {// 53
+            System.out.println("1");// 54
+         }
+      }
+   }
+
+   public static void testFinallyContinue() {
+      boolean a = Math.random() > 0.0;// 61
 
       while(true) {
          while(true) {
             try {
-               System.out.println("1");// 49
+               System.out.println("1");// 65
                break;
             } finally {
-               if (a) {// 52
-                  System.out.println("3");// 53
-                  continue;// 54
+               if (a) {// 68
+                  System.out.println("3");// 69
+                  continue;// 70
                }
             }
          }
 
-         System.out.println("4");// 58
+         System.out.println("4");// 74
       }
    }
 
    public static int testWhileCombined(String in) {
-      int len = in.length();// 63
-      int i = 0;// 64
-      boolean decSeen = false;// 65
-      boolean signSeen = false;// 66
-      int decPt = 0;// 67
-      int nLeadZero = 0;// 69
+      int len = in.length();// 79
+      int i = 0;// 80
+      boolean decSeen = false;// 81
+      boolean signSeen = false;// 82
+      int decPt = 0;// 83
+      int nLeadZero = 0;// 85
 
-      for(int nTrailZero = 0; i < len; ++i) {// 70 73 90
-         char c = in.charAt(i);// 74
-         if (c == '0') {// 75
-            ++nLeadZero;// 76
+      for(int nTrailZero = 0; i < len; ++i) {// 86 89 106
+         char c = in.charAt(i);// 90
+         if (c == '0') {// 91
+            ++nLeadZero;// 92
          } else {
-            if (c != '.') {// 77
+            if (c != '.') {// 93
                break;
             }
 
-            if (decSeen) {// 78
-               throw new NumberFormatException("multiple points");// 80
+            if (decSeen) {// 94
+               throw new NumberFormatException("multiple points");// 96
             }
 
-            decPt = i;// 82
-            if (signSeen) {// 83
-               decPt = i - 1;// 84
+            decPt = i;// 98
+            if (signSeen) {// 99
+               decPt = i - 1;// 100
             }
 
-            decSeen = true;// 86
+            decSeen = true;// 102
          }
       }
 
-      return decPt;// 92
+      return decPt;// 108
    }
 }
 
@@ -103,103 +117,124 @@ class 'pkg/TestClassLoop' {
       2b      18
    }
 
-   method 'testFinallyContinue ()V' {
+   method 'testCatch ()V' {
       0      24
       1      24
       2      24
       3      24
       4      24
       d      24
-      e      29
-      f      29
-      10      29
-      11      29
+      e      28
+      f      28
       12      29
-      13      29
-      25      32
-      26      32
-      2a      33
-      2b      33
-      2c      33
-      2d      33
-      2e      33
-      2f      33
-      30      33
-      31      33
-      32      34
-      37      39
-      38      39
-      39      39
-      3a      39
-      3b      39
-      3c      39
+      16      31
+      17      32
+      18      32
+      19      32
+      1a      32
+      1b      32
+      1c      32
+      1d      32
+      1e      32
+   }
+
+   method 'testFinallyContinue ()V' {
+      0      38
+      1      38
+      2      38
+      3      38
+      4      38
+      d      38
+      e      43
+      f      43
+      10      43
+      11      43
+      12      43
+      13      43
+      25      46
+      26      46
+      2a      47
+      2b      47
+      2c      47
+      2d      47
+      2e      47
+      2f      47
+      30      47
+      31      47
+      32      48
+      37      53
+      38      53
+      39      53
+      3a      53
+      3b      53
+      3c      53
    }
 
    method 'testWhileCombined (Ljava/lang/String;)I' {
-      0      44
-      1      44
-      2      44
-      3      44
-      4      44
-      5      45
-      6      45
-      7      46
-      8      46
-      9      47
-      a      47
-      b      47
-      c      48
-      d      48
-      e      48
-      f      49
-      10      49
-      11      49
-      12      51
-      13      51
-      14      51
-      15      51
-      16      51
-      17      51
-      1a      52
-      1b      52
-      1c      52
-      1d      52
-      1e      52
-      1f      52
-      20      52
-      21      53
-      22      53
-      23      53
-      24      53
-      25      53
-      28      54
-      29      54
-      2a      54
-      2e      56
-      2f      56
-      30      56
-      31      56
-      32      56
-      35      60
-      36      60
-      3d      61
-      3e      61
-      42      61
-      43      64
-      44      64
-      45      64
-      46      65
-      47      65
-      48      65
-      4b      66
-      4e      69
-      4f      69
-      50      51
-      51      51
-      52      51
-      56      73
-      57      73
-      58      73
+      0      58
+      1      58
+      2      58
+      3      58
+      4      58
+      5      59
+      6      59
+      7      60
+      8      60
+      9      61
+      a      61
+      b      61
+      c      62
+      d      62
+      e      62
+      f      63
+      10      63
+      11      63
+      12      65
+      13      65
+      14      65
+      15      65
+      16      65
+      17      65
+      1a      66
+      1b      66
+      1c      66
+      1d      66
+      1e      66
+      1f      66
+      20      66
+      21      67
+      22      67
+      23      67
+      24      67
+      25      67
+      28      68
+      29      68
+      2a      68
+      2e      70
+      2f      70
+      30      70
+      31      70
+      32      70
+      35      74
+      36      74
+      3d      75
+      3e      75
+      42      75
+      43      78
+      44      78
+      45      78
+      46      79
+      47      79
+      48      79
+      4b      80
+      4e      83
+      4f      83
+      50      65
+      51      65
+      52      65
+      56      87
+      57      87
+      58      87
    }
 }
 
@@ -210,31 +245,37 @@ Lines mapping:
 34 <-> 16
 38 <-> 19
 45 <-> 25
-49 <-> 30
-52 <-> 33
-53 <-> 34
-54 <-> 35
-58 <-> 40
-63 <-> 45
-64 <-> 46
-65 <-> 47
-66 <-> 48
-67 <-> 49
-69 <-> 50
-70 <-> 52
-73 <-> 52
-74 <-> 53
-75 <-> 54
-76 <-> 55
-77 <-> 57
-78 <-> 61
-80 <-> 62
-82 <-> 65
-83 <-> 66
-84 <-> 67
-86 <-> 70
-90 <-> 52
-92 <-> 74
+49 <-> 29
+50 <-> 30
+53 <-> 32
+54 <-> 33
+61 <-> 39
+65 <-> 44
+68 <-> 47
+69 <-> 48
+70 <-> 49
+74 <-> 54
+79 <-> 59
+80 <-> 60
+81 <-> 61
+82 <-> 62
+83 <-> 63
+85 <-> 64
+86 <-> 66
+89 <-> 66
+90 <-> 67
+91 <-> 68
+92 <-> 69
+93 <-> 71
+94 <-> 75
+96 <-> 76
+98 <-> 79
+99 <-> 80
+100 <-> 81
+102 <-> 84
+106 <-> 66
+108 <-> 88
 Not mapped:
 39
-56
+55
+72

--- a/testData/results/pkg/TestLoopFinally.dec
+++ b/testData/results/pkg/TestLoopFinally.dec
@@ -57,99 +57,49 @@ public class TestLoopFinally {
       System.out.println("after");// 59
    }// 60
 
-   public int test3(int param1) {
-      // $FF: Couldn't be decompiled
-      // Bytecode:
-      // 00: iload 1
-      // 01: bipush 1
-      // 02: if_icmpne 11
-      // 05: bipush 1
-      // 06: istore 2
-      // 07: iload 1
-      // 08: bipush 3
-      // 09: if_icmpne 0f
-      // 0c: goto 5e
-      // 0f: iload 2
-      // 10: ireturn
-      // 11: getstatic java/lang/System.out Ljava/io/PrintStream;
-      // 14: ldc "Oops"
-      // 16: invokevirtual java/io/PrintStream.println (Ljava/lang/String;)V
-      // 19: iload 1
-      // 1a: bipush 23
-      // 1c: if_icmpne 2b
-      // 1f: bipush 1
-      // 20: istore 2
-      // 21: iload 1
-      // 22: bipush 3
-      // 23: if_icmpne 29
-      // 26: goto 5e
-      // 29: iload 2
-      // 2a: ireturn
-      // 2b: getstatic java/lang/System.out Ljava/io/PrintStream;
-      // 2e: ldc "Oops"
-      // 30: invokevirtual java/io/PrintStream.println (Ljava/lang/String;)V
-      // 33: iload 1
-      // 34: bipush 25
-      // 36: if_icmpne 45
-      // 39: bipush 1
-      // 3a: istore 2
-      // 3b: iload 1
-      // 3c: bipush 3
-      // 3d: if_icmpne 43
-      // 40: goto 5e
-      // 43: iload 2
-      // 44: ireturn
-      // 45: iload 1
-      // 46: bipush 3
-      // 47: if_icmpne 58
-      // 4a: goto 5e
-      // 4d: astore 3
-      // 4e: iload 1
-      // 4f: bipush 3
-      // 50: if_icmpne 56
-      // 53: goto 5e
-      // 56: aload 3
-      // 57: athrow
-      // 58: iload 1
-      // 59: bipush 45
-      // 5b: if_icmplt 00
-      // 5e: getstatic java/lang/System.out Ljava/io/PrintStream;
-      // 61: bipush 5
-      // 62: invokevirtual java/io/PrintStream.print (I)V
-      // 65: bipush 1
-      // 66: ireturn
+   public int test3(int x) {
+      do {
+         try {
+            if (x == 1) {// 66
+               return 1;// 67
+            }
+
+            System.out.println("Oops");// 70
+            if (x == 23) {// 71
+               return 1;// 72
+            }
+
+            System.out.println("Oops");// 75
+            if (x == 25) {// 76
+               return 1;// 77
+            }
+         } finally {
+            if (x != 3) {// 80
+               ;
+            }
+            break;
+         }
+      } while(x < 45);// 84
+
+      System.out.print(5);// 86
+      return 1;// 87
    }
 
-   public int test4(int param1) {
-      // $FF: Couldn't be decompiled
-      // Bytecode:
-      // 00: iload 1
-      // 01: bipush 25
-      // 03: if_icmpge 12
-      // 06: bipush 5
-      // 07: istore 2
-      // 08: iload 1
-      // 09: bipush 3
-      // 0a: if_icmple 10
-      // 0d: goto 2b
-      // 10: iload 2
-      // 11: ireturn
-      // 12: iload 1
-      // 13: bipush 3
-      // 14: if_icmple 25
-      // 17: goto 2b
-      // 1a: astore 3
-      // 1b: iload 1
-      // 1c: bipush 3
-      // 1d: if_icmple 23
-      // 20: goto 2b
-      // 23: aload 3
-      // 24: athrow
-      // 25: iload 1
-      // 26: bipush 45
-      // 28: if_icmplt 00
-      // 2b: bipush 1
-      // 2c: ireturn
+   public int test4(int x) {
+      do {
+         try {
+            if (x < 25) {// 94
+               return 5;// 95
+            }
+         } finally {
+            if (x > 3) {// 98
+               return 1;// 104
+            }
+
+         }
+      } while(x < 45);// 102
+
+      return 1;
    }
 }
 
@@ -299,6 +249,76 @@ class 'pkg/TestLoopFinally' {
       3d      56
       3e      57
    }
+
+   method 'test3 (I)I' {
+      0      62
+      1      62
+      2      62
+      5      63
+      10      63
+      11      66
+      12      66
+      13      66
+      14      66
+      15      66
+      16      66
+      17      66
+      18      66
+      19      67
+      1a      67
+      1b      67
+      1c      67
+      1f      68
+      2a      68
+      2b      71
+      2c      71
+      2d      71
+      2e      71
+      2f      71
+      30      71
+      31      71
+      32      71
+      33      72
+      34      72
+      35      72
+      36      72
+      39      73
+      44      73
+      4d      76
+      4e      76
+      4f      76
+      58      81
+      59      81
+      5a      81
+      5b      81
+      5e      83
+      5f      83
+      60      83
+      61      83
+      62      83
+      63      83
+      64      83
+      65      84
+      66      84
+   }
+
+   method 'test4 (I)I' {
+      0      90
+      1      90
+      2      90
+      3      90
+      6      91
+      11      91
+      1a      94
+      1b      94
+      1c      94
+      25      99
+      26      99
+      27      99
+      28      99
+      2b      95
+      2c      95
+   }
 }
 
 Lines mapping:
@@ -328,7 +348,28 @@ Lines mapping:
 51 <-> 50
 59 <-> 57
 60 <-> 58
+66 <-> 63
+67 <-> 64
+70 <-> 67
+71 <-> 68
+72 <-> 69
+75 <-> 72
+76 <-> 73
+77 <-> 74
+80 <-> 77
+84 <-> 82
+86 <-> 84
+87 <-> 85
+94 <-> 91
+95 <-> 92
+98 <-> 95
+102 <-> 100
+104 <-> 96
 Not mapped:
 12
 38
 52
+81
+83
+99
+101

--- a/testData/results/pkg/TestLoopFinally.dec
+++ b/testData/results/pkg/TestLoopFinally.dec
@@ -101,6 +101,25 @@ public class TestLoopFinally {
 
       return 1;
    }
+
+   public int test5(int x) {
+      do {
+         try {
+            if (x < 25) {// 114
+               int var2 = 5;// 115
+               byte var3;
+               return var2 + var3;// 128
+            }
+         } finally {
+            if (x > 3) {// 119 120
+               return 1;// 126
+            }
+
+         }
+      } while(x < 45);// 124
+
+      return 1;
+   }
 }
 
 class 'pkg/TestLoopFinally' {
@@ -319,6 +338,28 @@ class 'pkg/TestLoopFinally' {
       2b      95
       2c      95
    }
+
+   method 'test5 (I)I' {
+      0      107
+      1      107
+      2      107
+      3      107
+      6      108
+      7      108
+      1f      113
+      20      113
+      21      113
+      2b      118
+      2c      118
+      2d      118
+      2e      118
+      31      114
+      32      114
+      33      110
+      34      110
+      35      110
+      36      110
+   }
 }
 
 Lines mapping:
@@ -365,6 +406,13 @@ Lines mapping:
 98 <-> 95
 102 <-> 100
 104 <-> 96
+114 <-> 108
+115 <-> 109
+119 <-> 114
+120 <-> 114
+124 <-> 119
+126 <-> 115
+128 <-> 111
 Not mapped:
 12
 38
@@ -373,3 +421,5 @@ Not mapped:
 83
 99
 101
+121
+123

--- a/testData/src/java8/pkg/TestClassLoop.java
+++ b/testData/src/java8/pkg/TestClassLoop.java
@@ -40,6 +40,22 @@ public class TestClassLoop {
     }
   }
 
+  public static void testCatch() {
+
+    boolean a = (Math.random() > 0);
+
+    while (true) {
+      try {
+        if (!a) {
+          return;
+        }
+      }
+      catch (Exception e) {
+        System.out.println("1");
+      }
+    }
+  }
+
   public static void testFinallyContinue() {
 
     boolean a = (Math.random() > 0);

--- a/testData/src/java8/pkg/TestLoopFinally.java
+++ b/testData/src/java8/pkg/TestLoopFinally.java
@@ -103,4 +103,28 @@ public class TestLoopFinally {
 
     return 1;
   }
+
+  public int test5(int x) {
+    int var2;
+    int var3;
+    l:
+    {
+      do {
+        try {
+          if (x < 25) {
+            var2 = 5;
+            break l;
+          }
+        } finally {
+          var3 = x;
+          if (x > 3) {
+            break;
+          }
+        }
+      } while (x < 45);
+
+      return 1;
+    }
+    return var2 + var3;
+  }
 }


### PR DESCRIPTION
Fixes cases with inaccessible direct graph nodes for validation, and fix a case where finally statements' successor edges were not put in the direct graph, causing certain methods to fail to decompile.