### PR TITLE
feat: SourceFile debug comments

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -274,7 +274,7 @@ public class ClassWriter {
 
       DecompilerContext.getLogger().startWriteClass(cl.qualifiedName);
 
-      if (DecompilerContext.getOption(IFernflowerPreferences.DECOMPILER_COMMENTS)) {
+      if (DecompilerContext.getOption(IFernflowerPreferences.SOURCE_FILE_COMMENTS)) {
         StructSourceFileAttribute sourceFileAttr = node.classStruct
           .getAttribute(StructGeneralAttribute.ATTRIBUTE_SOURCE_FILE);
 

--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -274,6 +274,21 @@ public class ClassWriter {
 
       DecompilerContext.getLogger().startWriteClass(cl.qualifiedName);
 
+      if (DecompilerContext.getOption(IFernflowerPreferences.DECOMPILER_COMMENTS)) {
+        StructSourceFileAttribute sourceFileAttr = node.classStruct
+          .getAttribute(StructGeneralAttribute.ATTRIBUTE_SOURCE_FILE);
+
+        if (sourceFileAttr != null) {
+          ConstantPool pool = node.classStruct.getPool();
+          String sourceFile = sourceFileAttr.getSourceFile(pool);
+
+          buffer
+            .appendIndent(indent)
+            .append("// $FF: Compiled from " + sourceFile)
+            .appendLineSeparator();
+        }
+      }
+
       // write class definition
       writeClassDefinition(node, buffer, indent);
 

--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
@@ -235,6 +235,10 @@ public interface IFernflowerPreferences {
   @Description("Sometimes, odd behavior of the bytecode or unfixable problems occur. This enables or disables the adding of those to the decompiled output.")
   String DECOMPILER_COMMENTS = "dec";
 
+  @Name("SourceFile comments")
+  @Description("Add debug comments showing the class SourceFile attribute if present.")
+  String SOURCE_FILE_COMMENTS = "sfc";
+
   Map<String, Object> DEFAULTS = getDefaults();
 
   static Map<String, Object> getDefaults() {
@@ -299,6 +303,7 @@ public interface IFernflowerPreferences {
     defaults.put(DUMP_BYTECODE_ON_ERROR, "1");
     defaults.put(DUMP_EXCEPTION_ON_ERROR, "1");
     defaults.put(DECOMPILER_COMMENTS, "1");
+    defaults.put(SOURCE_FILE_COMMENTS, "0");
 
     return Collections.unmodifiableMap(defaults);
   }

--- a/src/org/jetbrains/java/decompiler/struct/attr/StructGeneralAttribute.java
+++ b/src/org/jetbrains/java/decompiler/struct/attr/StructGeneralAttribute.java
@@ -38,6 +38,7 @@ public class StructGeneralAttribute {
   public static final Key<StructModuleAttribute> ATTRIBUTE_MODULE = new Key<>("Module");
   public static final Key<StructRecordAttribute> ATTRIBUTE_RECORD = new Key<>("Record");
   public static final Key<StructPermittedSubclassesAttribute> ATTRIBUTE_PERMITTED_SUBCLASSES = new Key<>("PermittedSubclasses");
+  public static final Key<StructSourceFileAttribute> ATTRIBUTE_SOURCE_FILE = new Key<>("SourceFile");
 
   @SuppressWarnings("unused")
   public static class Key<T extends StructGeneralAttribute> {
@@ -105,6 +106,9 @@ public class StructGeneralAttribute {
     }
     else if (ATTRIBUTE_PERMITTED_SUBCLASSES.name.equals(name)) {
       return new StructPermittedSubclassesAttribute();
+    }
+    else if (ATTRIBUTE_SOURCE_FILE.name.equals(name)) {
+      return new StructSourceFileAttribute();
     }
     else {
       return null; // unsupported attribute

--- a/src/org/jetbrains/java/decompiler/struct/attr/StructSourceFileAttribute.java
+++ b/src/org/jetbrains/java/decompiler/struct/attr/StructSourceFileAttribute.java
@@ -1,0 +1,27 @@
+package org.jetbrains.java.decompiler.struct.attr;
+
+import org.jetbrains.java.decompiler.code.BytecodeVersion;
+import org.jetbrains.java.decompiler.struct.consts.ConstantPool;
+import org.jetbrains.java.decompiler.util.DataInputFullStream;
+
+import java.io.IOException;
+
+/*
+  SourceFile_attribute {
+    u2 attribute_name_index;
+    u4 attribute_length;
+    u2 sourcefile_index;
+  }
+ */
+public class StructSourceFileAttribute extends StructGeneralAttribute {
+  private int constPoolIndex;
+
+  @Override
+  public void initContent(DataInputFullStream data, ConstantPool pool, BytecodeVersion version) throws IOException {
+    constPoolIndex = data.readUnsignedShort();
+  }
+
+  public String getSourceFile(ConstantPool pool) {
+    return pool.getPrimitiveConstant(constPoolIndex).getString();
+  }
+}


### PR DESCRIPTION
Unless stripped, the SourceFile attribute contains some pretty valuable information.

Implementation example:
```java
// $FF: compiled from test.java
class Main {
   public static void main(String[] var0) {
      System.out.println("abc");
   }

   // $FF: compiled from test.java
   private class InternalClass {
   }
}
```