### PR TITLE
build: Bump Kotlin version to 1.6.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 import org.jetbrains.java.decompiler.build.JasmCompile
 
 plugins {
-  id 'org.jetbrains.kotlin.jvm' version '1.5.21'
+  id 'org.jetbrains.kotlin.jvm' version '1.6.21'
 }
 
 apply plugin: 'java'

--- a/testData/results/pkg/TestIllegalVarName.dec
+++ b/testData/results/pkg/TestIllegalVarName.dec
@@ -5,7 +5,7 @@ import kotlin.jvm.internal.Intrinsics;
 import org.jetbrains.annotations.NotNull;
 
 @Metadata(
-   mv = {1, 5, 1},
+   mv = {1, 6, 0},
    k = 1,
    xi = 48,
    d1 = {"\u0000\u001a\n\u0002\u0018\u0002\n\u0002\u0010\u0000\n\u0002\b\u0002\n\u0002\u0010\u000e\n\u0002\b\u0002\n\u0002\u0010\b\n\u0000\u0018\u00002\u00020\u0001B\u0005¢\u0006\u0002\u0010\u0002J\u0016\u0010\u0003\u001a\u00020\u00042\u0006\u0010\u0005\u001a\u00020\u00042\u0006\u0010\u0006\u001a\u00020\u0007¨\u0006\b"},

--- a/testData/results/pkg/TestKotlinConstructorKt.dec
+++ b/testData/results/pkg/TestKotlinConstructorKt.dec
@@ -7,7 +7,7 @@ import kotlin.Metadata;
 import kotlin.collections.CollectionsKt;
 
 @Metadata(
-   mv = {1, 5, 1},
+   mv = {1, 6, 0},
    k = 2,
    xi = 48,
    d1 = {"\u0000\u0016\n\u0000\n\u0002\u0010 \n\u0002\u0018\u0002\n\u0000\n\u0002\u0010\u001e\n\u0002\u0010\u000e\n\u0000\u001a\u001e\u0010\u0000\u001a\b\u0012\u0004\u0012\u00020\u00020\u00012\u000e\u0010\u0003\u001a\n\u0012\u0006\u0012\u0004\u0018\u00010\u00050\u0004H\u0002¨\u0006\u0006"},
@@ -29,8 +29,7 @@ public final class TestKotlinConstructorKt {
          }
 
          var10000./* $FF: Unable to resugar constructor */<init>(it);
-         Mapping var11 = var10000;
-         destination$iv$iv.add(var11);// 14
+         destination$iv$iv.add(var10000);// 14
       }
 
       return CollectionsKt.toList((List)destination$iv$iv);// 4 6 15
@@ -77,8 +76,8 @@ class 'pkg/TestKotlinConstructorKt' {
       36      22
       37      22
       38      22
-      39      32
-      3a      32
+      39      31
+      3a      31
       3b      23
       3c      23
       3d      23
@@ -91,44 +90,38 @@ class 'pkg/TestKotlinConstructorKt' {
       46      24
       4b      26
       4c      26
-      4d      26
-      54      27
-      55      27
-      59      27
-      5a      30
-      5b      30
+      4e      26
+      56      27
+      57      27
+      5b      27
       5c      30
       5d      30
       5e      30
-      5f      31
-      60      31
-      63      32
-      64      32
-      65      32
-      66      32
-      67      32
-      68      32
-      69      32
-      6e      35
-      6f      35
-      70      35
-      71      35
-      72      35
-      74      35
-      75      35
-      76      35
-      77      35
-      78      35
-      79      35
-      7a      35
+      62      31
+      63      31
+      64      31
+      65      31
+      66      31
+      6b      34
+      6c      34
+      6d      34
+      6e      34
+      6f      34
+      71      34
+      72      34
+      73      34
+      74      34
+      75      34
+      76      34
+      77      34
    }
 }
 
 Lines mapping:
-4 <-> 36
+4 <-> 35
 5 <-> 27
-6 <-> 36
+6 <-> 35
 12 <-> 23
 13 <-> 23
-14 <-> 33
-15 <-> 36
+14 <-> 32
+15 <-> 35

--- a/testData/results/pkg/TestKotlinEnumWhen.dec
+++ b/testData/results/pkg/TestKotlinEnumWhen.dec
@@ -3,10 +3,9 @@ package pkg;
 import kotlin.DeprecationLevel;
 import kotlin.Metadata;
 import kotlin.NoWhenBranchMatchedException;
-import kotlin.jvm.internal.Intrinsics;
 
 @Metadata(
-   mv = {1, 5, 1},
+   mv = {1, 6, 0},
    k = 1,
    xi = 48,
    d1 = {"\u0000\u0014\n\u0002\u0018\u0002\n\u0002\u0010\u0010\n\u0002\b\u0002\n\u0002\u0010\u0002\n\u0002\b\b\b\u0086\u0001\u0018\u00002\b\u0012\u0004\u0012\u00020\u00000\u0001B\u0007\b\u0002¢\u0006\u0002\u0010\u0002J\u0006\u0010\u0003\u001a\u00020\u0004J\u0006\u0010\u0005\u001a\u00020\u0004J\u0006\u0010\u0006\u001a\u00020\u0004J\u0006\u0010\u0007\u001a\u00020\u0004J\u0006\u0010\b\u001a\u00020\u0004j\u0002\b\tj\u0002\b\nj\u0002\b\u000b¨\u0006\f"},
@@ -20,19 +19,13 @@ public enum TestKotlinEnumWhen {
    public final void testStatement() {
       switch(this) {// 7
          case FIRST:
-            String var6 = "first!";// 8
-            boolean var8 = false;
-            System.out.println(var6);
+            System.out.println("first!");// 8
             break;
          case SECOND:
-            String var5 = "second!";// 9
-            boolean var7 = false;
-            System.out.println(var5);
+            System.out.println("second!");// 9
             break;
          case THIRD:
-            String var3 = "third!";// 10
-            boolean var4 = false;
-            System.out.println(var3);
+            System.out.println("third!");// 10
       }
 
    }// 12
@@ -54,27 +47,20 @@ public enum TestKotlinEnumWhen {
       }
 
       String var1 = var10000;
-      boolean var3 = false;// 15
-      System.out.println(var1);
+      System.out.println(var1);// 15
    }// 22
 
    public final void testAnotherEnum() {
       DeprecationLevel level = testAnotherEnum$getLevel();// 28
       switch(level) {
          case WARNING:
-            String var6 = Intrinsics.stringPlus("warning ", level);// 29
-            boolean var8 = false;
-            System.out.println(var6);
+            System.out.println("warning " + level);// 29
             break;
          case ERROR:
-            String var5 = Intrinsics.stringPlus("error ", level);// 30
-            boolean var7 = false;
-            System.out.println(var5);
+            System.out.println("error " + level);// 30
             break;
          case HIDDEN:
-            String var3 = Intrinsics.stringPlus("hidden ", level);// 31
-            boolean var4 = false;
-            System.out.println(var3);
+            System.out.println("hidden " + level);// 31
       }
 
    }// 33
@@ -82,36 +68,24 @@ public enum TestKotlinEnumWhen {
    public final void testConsecutive() {
       switch(this) {// 36
          case FIRST:
-            String var7 = "first!";// 37
-            boolean var12 = false;
-            System.out.println(var7);
+            System.out.println("first!");// 37
             break;
          case SECOND:
-            String var6 = "second!";// 38
-            boolean var11 = false;
-            System.out.println(var6);
+            System.out.println("second!");// 38
             break;
          case THIRD:
-            String var3 = "third!";// 39
-            boolean var4 = false;
-            System.out.println(var3);
+            System.out.println("third!");// 39
       }
 
       switch(this) {// 42
          case FIRST:
-            String var10 = "first, again!";// 43
-            boolean var15 = false;
-            System.out.println(var10);
+            System.out.println("first, again!");// 43
             break;
          case SECOND:
-            String var9 = "second, again!";// 44
-            boolean var14 = false;
-            System.out.println(var9);
+            System.out.println("second, again!");// 44
             break;
          case THIRD:
-            String var8 = "third, again!";// 45
-            boolean var13 = false;
-            System.out.println(var8);
+            System.out.println("third, again!");// 45
       }
 
    }// 47
@@ -120,36 +94,24 @@ public enum TestKotlinEnumWhen {
       DeprecationLevel level = testConsecutiveMixed$getLevel-0();// 53
       switch(level) {
          case WARNING:
-            String var7 = Intrinsics.stringPlus("warning ", level);// 54
-            boolean var12 = false;
-            System.out.println(var7);
+            System.out.println("warning " + level);// 54
             break;
          case ERROR:
-            String var6 = Intrinsics.stringPlus("error ", level);// 55
-            boolean var11 = false;
-            System.out.println(var6);
+            System.out.println("error " + level);// 55
             break;
          case HIDDEN:
-            String var3 = Intrinsics.stringPlus("hidden ", level);// 56
-            boolean var4 = false;
-            System.out.println(var3);
+            System.out.println("hidden " + level);// 56
       }
 
       switch(this) {// 59
          case FIRST:
-            String var10 = "first!";// 60
-            boolean var15 = false;
-            System.out.println(var10);
+            System.out.println("first!");// 60
             break;
          case SECOND:
-            String var9 = "second!";// 61
-            boolean var14 = false;
-            System.out.println(var9);
+            System.out.println("second!");// 61
             break;
          case THIRD:
-            String var8 = "third!";// 62
-            boolean var13 = false;
-            System.out.println(var8);
+            System.out.println("third!");// 62
       }
 
    }// 64
@@ -165,368 +127,276 @@ public enum TestKotlinEnumWhen {
 
 class 'pkg/TestKotlinEnumWhen' {
    method 'testStatement ()V' {
-      0      20
-      c      20
-      28      22
-      29      22
-      2a      22
-      2b      23
-      2c      23
-      2d      23
-      2e      24
-      2f      24
+      0      19
+      9      19
+      24      21
+      25      21
+      26      21
+      27      21
+      28      21
+      2a      21
+      2b      21
+      2c      21
+      2d      22
       30      24
       31      24
       32      24
       33      24
       34      24
-      35      25
-      38      27
-      39      27
-      3a      27
-      3b      28
-      3c      28
-      3d      28
-      3e      29
-      3f      29
-      40      29
-      41      29
-      42      29
-      43      29
-      44      29
+      36      24
+      37      24
+      38      24
+      39      25
+      3c      27
+      3d      27
+      3e      27
+      3f      27
+      40      27
+      42      27
       45      30
-      48      32
-      49      32
-      4a      32
-      4b      33
-      4c      33
-      4d      33
-      4e      34
-      4f      34
-      50      34
-      51      34
-      52      34
-      55      37
    }
 
    method 'testExpression ()V' {
-      0      41
-      c      41
-      28      43
-      29      43
-      2a      44
-      2d      46
-      2e      46
-      2f      47
-      32      49
-      33      49
-      34      50
-      3e      52
-      3f      55
-      40      56
-      41      56
-      42      57
-      43      57
-      44      57
-      45      57
-      46      57
-      47      57
-      48      57
-      49      58
+      0      34
+      9      34
+      24      36
+      25      36
+      26      37
+      29      39
+      2a      39
+      2b      40
+      2e      42
+      2f      42
+      30      43
+      3a      45
+      3b      48
+      3c      49
+      3d      49
+      3e      49
+      3f      49
+      40      49
+      41      49
+      42      49
+      43      50
    }
 
    method 'testAnotherEnum ()V' {
-      0      61
-      1      61
-      2      61
-      3      61
-      7      62
-      e      62
-      28      64
-      29      64
-      2a      64
-      2b      64
-      2c      64
-      2d      64
-      2e      64
-      2f      65
-      30      65
-      31      65
-      32      66
-      33      66
-      34      66
-      35      66
-      36      66
-      37      66
-      38      66
-      39      67
-      3c      69
-      3d      69
-      3e      69
-      3f      69
-      40      69
-      41      69
-      42      69
-      43      70
-      44      70
-      45      70
-      46      71
-      47      71
-      48      71
-      49      71
-      4a      71
-      4b      71
-      4c      71
-      4d      72
-      50      74
-      51      74
-      52      74
-      53      74
-      54      74
-      55      74
-      56      74
-      57      75
-      58      75
-      59      75
-      5a      76
-      5b      76
-      5c      76
-      5d      76
-      5e      76
-      61      79
+      0      53
+      1      53
+      2      53
+      3      53
+      7      54
+      c      54
+      2f      56
+      30      56
+      34      56
+      38      56
+      39      56
+      3a      56
+      3b      56
+      3c      56
+      3d      56
+      3f      56
+      40      56
+      41      56
+      42      57
+      4c      59
+      4d      59
+      51      59
+      55      59
+      56      59
+      57      59
+      58      59
+      59      59
+      5a      59
+      5c      59
+      5d      59
+      5e      59
+      5f      60
+      69      62
+      6a      62
+      6e      62
+      72      62
+      73      62
+      74      62
+      75      62
+      76      62
+      77      62
+      79      62
+      7c      65
    }
 
    method 'testConsecutive ()V' {
-      0      82
-      c      82
-      28      84
-      29      84
-      2a      84
-      2b      85
-      2c      85
-      2d      85
-      2e      86
-      2f      86
-      30      86
-      31      86
-      32      86
-      33      86
-      34      86
-      35      87
-      38      89
-      39      89
-      3a      89
-      3b      90
-      3c      90
-      3d      90
-      3e      91
-      3f      91
-      40      91
-      41      91
-      42      91
-      43      91
-      44      91
-      45      92
-      48      94
-      49      94
-      4a      94
-      4b      95
-      4c      95
-      4d      95
-      4e      96
-      4f      96
-      50      96
-      51      96
-      52      96
-      55      99
-      61      99
-      7c      101
-      7d      101
-      7e      101
-      7f      102
-      80      102
-      81      102
-      82      103
-      83      103
-      84      103
-      85      103
-      86      103
-      87      103
-      88      103
-      89      104
-      8c      106
-      8d      106
-      8e      106
-      8f      107
-      90      107
-      91      107
-      92      108
-      93      108
-      94      108
-      95      108
-      96      108
-      97      108
-      98      108
-      99      109
-      9c      111
-      9d      111
-      9e      111
-      9f      112
-      a0      112
-      a1      112
-      a2      113
-      a3      113
-      a4      113
-      a5      113
-      a6      113
-      a9      116
+      0      68
+      9      68
+      24      70
+      25      70
+      26      70
+      27      70
+      28      70
+      2a      70
+      2b      70
+      2c      70
+      2d      71
+      30      73
+      31      73
+      32      73
+      33      73
+      34      73
+      36      73
+      37      73
+      38      73
+      39      74
+      3c      76
+      3d      76
+      3e      76
+      3f      76
+      40      76
+      42      76
+      45      79
+      4e      79
+      68      81
+      69      81
+      6a      81
+      6b      81
+      6c      81
+      6e      81
+      6f      81
+      70      81
+      71      82
+      74      84
+      75      84
+      76      84
+      77      84
+      78      84
+      7a      84
+      7b      84
+      7c      84
+      7d      85
+      80      87
+      81      87
+      82      87
+      83      87
+      84      87
+      86      87
+      89      90
    }
 
    method 'testConsecutiveMixed ()V' {
-      0      119
-      1      119
-      2      119
-      3      119
-      7      120
-      e      120
-      28      122
-      29      122
-      2a      122
-      2b      122
-      2c      122
-      2d      122
-      2e      122
-      2f      123
-      30      123
-      31      123
-      32      124
-      33      124
-      34      124
-      35      124
-      36      124
-      37      124
-      38      124
-      39      125
-      3c      127
-      3d      127
-      3e      127
-      3f      127
-      40      127
-      41      127
-      42      127
-      43      128
-      44      128
-      45      128
-      46      129
-      47      129
-      48      129
-      49      129
-      4a      129
-      4b      129
-      4c      129
-      4d      130
-      50      132
-      51      132
-      52      132
-      53      132
-      54      132
-      55      132
-      56      132
-      57      133
-      58      133
-      59      133
-      5a      134
-      5b      134
-      5c      134
-      5d      134
-      5e      134
-      61      137
-      6d      137
-      88      139
-      89      139
-      8a      139
-      8b      140
-      8c      140
-      8d      140
-      8e      141
-      8f      141
-      90      141
-      91      141
-      92      141
-      93      141
-      94      141
-      95      142
-      98      144
-      99      144
-      9a      144
-      9b      145
-      9c      145
-      9d      145
-      9e      146
-      9f      146
-      a0      146
-      a1      146
-      a2      146
-      a3      146
-      a4      146
-      a5      147
-      a8      149
-      a9      149
-      aa      149
-      ab      150
-      ac      150
-      ad      150
-      ae      151
-      af      151
-      b0      151
-      b1      151
-      b2      151
-      b5      154
+      0      93
+      1      93
+      2      93
+      3      93
+      7      94
+      c      94
+      2f      96
+      30      96
+      34      96
+      38      96
+      39      96
+      3a      96
+      3b      96
+      3c      96
+      3d      96
+      3f      96
+      40      96
+      41      96
+      42      97
+      4c      99
+      4d      99
+      51      99
+      55      99
+      56      99
+      57      99
+      58      99
+      59      99
+      5a      99
+      5c      99
+      5d      99
+      5e      99
+      5f      100
+      69      102
+      6a      102
+      6e      102
+      72      102
+      73      102
+      74      102
+      75      102
+      76      102
+      77      102
+      79      102
+      7c      105
+      85      105
+      a0      107
+      a1      107
+      a2      107
+      a3      107
+      a4      107
+      a6      107
+      a7      107
+      a8      107
+      a9      108
+      ac      110
+      ad      110
+      ae      110
+      af      110
+      b0      110
+      b2      110
+      b3      110
+      b4      110
+      b5      111
+      b8      113
+      b9      113
+      ba      113
+      bb      113
+      bc      113
+      be      113
+      c1      116
    }
 
    method 'testAnotherEnum$getLevel ()Lkotlin/DeprecationLevel;' {
-      7      157
+      7      119
    }
 
    method 'testConsecutiveMixed$getLevel-0 ()Lkotlin/DeprecationLevel;' {
-      7      161
+      7      123
    }
 }
 
 Lines mapping:
-7 <-> 21
-8 <-> 23
-9 <-> 28
-10 <-> 33
-12 <-> 38
-15 <-> 57
-16 <-> 42
-17 <-> 44
-18 <-> 47
-19 <-> 50
-22 <-> 59
-26 <-> 158
-28 <-> 62
-29 <-> 65
-30 <-> 70
-31 <-> 75
-33 <-> 80
-36 <-> 83
-37 <-> 85
-38 <-> 90
-39 <-> 95
-42 <-> 100
-43 <-> 102
-44 <-> 107
-45 <-> 112
-47 <-> 117
-51 <-> 162
-53 <-> 120
-54 <-> 123
-55 <-> 128
-56 <-> 133
-59 <-> 138
-60 <-> 140
-61 <-> 145
-62 <-> 150
-64 <-> 155
+7 <-> 20
+8 <-> 22
+9 <-> 25
+10 <-> 28
+12 <-> 31
+15 <-> 50
+16 <-> 35
+17 <-> 37
+18 <-> 40
+19 <-> 43
+22 <-> 51
+26 <-> 120
+28 <-> 54
+29 <-> 57
+30 <-> 60
+31 <-> 63
+33 <-> 66
+36 <-> 69
+37 <-> 71
+38 <-> 74
+39 <-> 77
+42 <-> 80
+43 <-> 82
+44 <-> 85
+45 <-> 88
+47 <-> 91
+51 <-> 124
+53 <-> 94
+54 <-> 97
+55 <-> 100
+56 <-> 103
+59 <-> 106
+60 <-> 108
+61 <-> 111
+62 <-> 114
+64 <-> 117

--- a/testData/results/pkg/TestNamedSuspendFun2Kt.dec
+++ b/testData/results/pkg/TestNamedSuspendFun2Kt.dec
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Metadata(
-   mv = {1, 5, 1},
+   mv = {1, 6, 0},
    k = 2,
    xi = 48,
    d1 = {"\u0000\n\n\u0000\n\u0002\u0010\b\n\u0002\b\u0003\u001a\u0011\u0010\u0000\u001a\u00020\u0001H\u0086@ø\u0001\u0000¢\u0006\u0002\u0010\u0002\u001a\u0011\u0010\u0003\u001a\u00020\u0001H\u0086@ø\u0001\u0000¢\u0006\u0002\u0010\u0002\u0082\u0002\u0004\n\u0002\b\u0019¨\u0006\u0004"},
@@ -36,7 +36,7 @@ public final class TestNamedSuspendFun2Kt {
          c = "pkg.TestNamedSuspendFun2Kt"
       )
       @Metadata(
-         mv = {1, 5, 1},
+         mv = {1, 6, 0},
          k = 3,
          xi = 48
       )
@@ -107,7 +107,7 @@ public final class TestNamedSuspendFun2Kt {
                   break;
                case 2:
                   ResultKt.throwOnFailure($result);
-                  return Boxing.boxInt(1);// 2 8 9 11
+                  return Boxing.boxInt(1);// 2 7 8 9 11
                case 3:
                   ResultKt.throwOnFailure($result);
                   break;
@@ -387,6 +387,7 @@ Lines mapping:
 4 <-> 125
 5 <-> 93
 6 <-> 94
+7 <-> 110
 8 <-> 110
 9 <-> 110
 11 <-> 110

--- a/testData/results/pkg/TestRunSuspend.dec
+++ b/testData/results/pkg/TestRunSuspend.dec
@@ -7,7 +7,7 @@ import kotlin.Unit;
 import org.jetbrains.annotations.Nullable;
 
 @Metadata(
-   mv = {1, 5, 1},
+   mv = {1, 6, 0},
    k = 1,
    xi = 48,
    d1 = {"\u0000\u0018\n\u0002\u0018\u0002\n\u0002\u0010\u0000\n\u0002\b\u0002\n\u0002\u0018\u0002\n\u0002\u0010\u0002\n\u0002\b\u0006\b\u0002\u0018\u00002\u00020\u0001B\u0005¢\u0006\u0002\u0010\u0002J\u0006\u0010\n\u001a\u00020\u0005R+\u0010\u0003\u001a\n\u0012\u0004\u0012\u00020\u0005\u0018\u00010\u0004X\u0086\u000eø\u0001\u0000ø\u0001\u0001ø\u0001\u0002¢\u0006\u000e\n\u0000\u001a\u0004\b\u0006\u0010\u0007\"\u0004\b\b\u0010\t\u0082\u0002\u000f\n\u0002\b\u0019\n\u0005\b¡\u001e0\u0001\n\u0002\b!¨\u0006\u000b"},
@@ -31,18 +31,15 @@ final class TestRunSuspend {
 
    // $FF: Extended synchronized range to monitorexit
    public final void await() {
-      boolean var1 = false;// 7
-      boolean var2 = false;
-      synchronized(this) {
+      synchronized(this) {// 7
          int $i$a$-synchronized-TestRunSuspend$await$1 = 0;
 
          while(true) {
-            Result result = this.getResult-xLWZpok();// 9
+            Result result = this.result;// 9
             if (result != null) {// 10
-               Object var5 = result.unbox-impl();// 12
-               boolean var6 = false;
-               ResultKt.throwOnFailure(var5);
-               return;// 13
+               Object var4 = result.unbox-impl();// 12
+               ResultKt.throwOnFailure(var4);
+               return;
             }
 
             this.wait();
@@ -75,45 +72,35 @@ class 'pkg/TestRunSuspend' {
 
    method 'await ()V' {
       0      33
-      1      33
-      2      34
-      3      34
-      4      35
-      5      35
-      7      36
-      8      36
-      a      39
-      b      39
-      c      39
-      d      39
-      e      39
-      f      39
-      10      40
-      11      40
-      12      40
-      15      47
-      16      47
-      17      47
-      18      47
-      19      47
-      1a      47
-      1b      47
-      1f      41
-      20      41
-      21      41
-      22      41
-      23      41
-      24      41
-      25      41
-      26      42
-      27      42
-      28      42
-      29      43
-      2a      43
-      2b      43
-      2c      43
-      2d      43
-      31      44
+      3      33
+      5      34
+      6      34
+      8      37
+      9      37
+      a      37
+      b      37
+      c      37
+      d      38
+      e      38
+      11      44
+      12      44
+      13      44
+      14      44
+      15      44
+      16      44
+      17      44
+      1b      39
+      1c      39
+      1d      39
+      1e      39
+      1f      39
+      20      39
+      21      40
+      22      40
+      23      40
+      24      40
+      25      40
+      29      41
    }
 }
 
@@ -121,9 +108,9 @@ Lines mapping:
 4 <-> 21
 5 <-> 29
 7 <-> 34
-9 <-> 40
-10 <-> 41
-12 <-> 42
-13 <-> 45
+9 <-> 38
+10 <-> 39
+12 <-> 40
 Not mapped:
 8
+13

--- a/testData/results/pkg/TestSuspendLambdaKt.dec
+++ b/testData/results/pkg/TestSuspendLambdaKt.dec
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Metadata(
-   mv = {1, 5, 1},
+   mv = {1, 6, 0},
    k = 2,
    xi = 48,
    d1 = {"\u0000\u0016\n\u0000\n\u0002\u0018\u0002\n\u0002\u0018\u0002\n\u0002\u0010\u0002\n\u0002\u0010\u0000\n\u0002\b\u0004\",\u0010\u0000\u001a\u0018\b\u0001\u0012\n\u0012\b\u0012\u0004\u0012\u00020\u00030\u0002\u0012\u0006\u0012\u0004\u0018\u00010\u00040\u0001ø\u0001\u0000¢\u0006\n\n\u0002\u0010\u0007\u001a\u0004\b\u0005\u0010\u0006\u0082\u0002\u0004\n\u0002\b\u0019¨\u0006\b"},
@@ -38,7 +38,7 @@ public final class TestSuspendLambdaKt {
          c = "pkg.TestSuspendLambdaKt$sl1$1"
       )
       @Metadata(
-         mv = {1, 5, 1},
+         mv = {1, 6, 0},
          k = 3,
          xi = 48,
          d1 = {"\u0000\u0006\n\u0000\n\u0002\u0010\u0002\u0010\u0000\u001a\u00020\u0001H\u008a@"},
@@ -53,13 +53,11 @@ public final class TestSuspendLambdaKt {
 
          @Nullable
          public final Object invokeSuspend(@NotNull Object $result) {
-            Object var4 = IntrinsicsKt.getCOROUTINE_SUSPENDED();
+            IntrinsicsKt.getCOROUTINE_SUSPENDED();
             switch(this.label) {
                case 0:
                   ResultKt.throwOnFailure($result);
-                  String var2 = "SL1";// 4
-                  boolean var3 = false;
-                  System.out.println(var2);
+                  System.out.println("SL1");// 4
                   return Unit.INSTANCE;// 5
                default:
                   throw new IllegalStateException("call to 'resume' before 'invoke' with coroutine");
@@ -89,7 +87,7 @@ class 'pkg/TestSuspendLambdaKt' {
    }
 
    method '<clinit> ()V' {
-      e      79
+      e      77
    }
 }
 
@@ -107,13 +105,11 @@ class 'pkg/TestSuspendLambdaKt$sl1$1' {
       0      55
       1      55
       2      55
-      3      55
-      4      55
+      4      56
       5      56
       6      56
       7      56
       8      56
-      9      56
       1c      58
       1d      58
       1e      58
@@ -121,52 +117,48 @@ class 'pkg/TestSuspendLambdaKt$sl1$1' {
       20      59
       21      59
       22      59
-      23      60
-      24      60
-      25      61
-      26      61
-      27      61
-      28      61
-      29      61
-      2a      61
-      2b      61
-      2c      62
-      2d      62
-      2e      62
-      2f      62
-      34      64
-      35      64
-      39      64
+      23      59
+      24      59
+      26      59
+      27      59
+      28      59
+      29      60
+      2a      60
+      2b      60
+      2c      60
+      31      62
+      32      62
+      36      62
    }
 
    method 'create (Lkotlin/coroutines/Continuation;)Lkotlin/coroutines/Continuation;' {
-      4      70
-      8      70
-      9      70
-      a      70
-      b      70
+      4      68
+      8      68
+      9      68
+      a      68
+      b      68
    }
 
    method 'invoke (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;' {
-      0      75
-      1      75
-      2      75
-      3      75
-      4      75
-      5      75
-      6      75
-      7      75
-      8      75
-      9      75
-      a      75
-      b      75
-      c      75
-      d      75
-      e      75
+      0      73
+      1      73
+      2      73
+      3      73
+      4      73
+      5      73
+      6      73
+      7      73
+      8      73
+      9      73
+      a      73
+      b      73
+      c      73
+      d      73
+      e      73
    }
 }
 
 Lines mapping:
-3 <-> 80
+3 <-> 78
 4 <-> 60
-5 <-> 63
+5 <-> 61

--- a/testData/results/pkg/TestSynchronizedUnprotected.dec
+++ b/testData/results/pkg/TestSynchronizedUnprotected.dec
@@ -4,7 +4,7 @@ import kotlin.Metadata;
 import kotlin.Unit;
 
 @Metadata(
-   mv = {1, 5, 1},
+   mv = {1, 6, 0},
    k = 1,
    xi = 48,
    d1 = {"\u0000\u0012\n\u0002\u0018\u0002\n\u0002\u0010\u0000\n\u0002\b\u0002\n\u0002\u0010\u0002\n\u0000\u0018\u00002\u00020\u0001B\u0005¢\u0006\u0002\u0010\u0002J\u0006\u0010\u0003\u001a\u00020\u0004¨\u0006\u0005"},
@@ -13,14 +13,10 @@ import kotlin.Unit;
 public final class TestSynchronizedUnprotected {
    // $FF: Extended synchronized range to monitorexit
    public final void test() {
-      boolean var1 = false;
-      boolean var2 = false;
       synchronized(this) {
          int $i$a$-synchronized-TestSynchronizedUnprotected$test$1 = 0;
-         String var4 = "Boom";// 6
-         boolean var5 = false;
-         System.out.println(var4);
-         Unit var7 = Unit.INSTANCE;// 5 7
+         System.out.println("Boom");// 6
+         Unit var4 = Unit.INSTANCE;// 5 7
       }
    }
 }
@@ -28,46 +24,35 @@ public final class TestSynchronizedUnprotected {
 class 'pkg/TestSynchronizedUnprotected' {
    method 'test ()V' {
       0      15
-      1      15
-      2      16
-      3      16
-      4      17
-      5      17
-      7      18
-      8      18
-      9      19
-      a      19
-      b      19
-      c      19
-      d      20
-      e      20
-      f      20
-      10      21
-      11      21
-      12      21
-      13      21
-      14      21
-      15      21
-      16      21
-      17      21
-      19      22
-      1a      22
-      1b      22
-      1c      22
-      1f      24
-      20      24
-      21      24
-      22      24
-      23      24
-      24      24
-      25      24
-      26      24
+      3      15
+      5      16
+      6      16
+      7      17
+      8      17
+      9      17
+      a      17
+      b      17
+      d      17
+      e      17
+      f      17
+      11      18
+      12      18
+      13      18
+      14      18
+      17      20
+      18      20
+      19      20
+      1a      20
+      1b      20
+      1c      20
+      1d      20
+      1e      20
    }
 }
 
 Lines mapping:
-5 <-> 23
-6 <-> 20
-7 <-> 23
+5 <-> 19
+6 <-> 18
+7 <-> 19
 Not mapped:
 8


### PR DESCRIPTION
This resolves issues with the kotlin compiler daemon on J17 (which should speed up builds a little bit)

As a bonus, the generated bytecode seems to be a fair bit cleaner now