### PR TITLE
Detect JAR/ZIP files with other file endings

### DIFF
--- a/src/org/jetbrains/java/decompiler/struct/JarContextSource.java
+++ b/src/org/jetbrains/java/decompiler/struct/JarContextSource.java
@@ -1,8 +1,6 @@
 // Copyright 2000-2022 JetBrains s.r.o. and ForgeFlower contributors Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.jetbrains.java.decompiler.struct;
 
-import static java.util.Objects.requireNonNull;
-
 import org.jetbrains.java.decompiler.main.DecompilerContext;
 import org.jetbrains.java.decompiler.main.extern.IBytecodeProvider;
 import org.jetbrains.java.decompiler.main.extern.IContextSource;
@@ -13,14 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+
+import static java.util.Objects.requireNonNull;
 
 final class JarContextSource implements IContextSource, AutoCloseable {
   private static final String MANIFEST = "META-INF/MANIFEST.MF";
@@ -30,7 +26,7 @@ final class JarContextSource implements IContextSource, AutoCloseable {
   private final String relativePath; // used for nested contexts from DirectoryContextSource
   private final File jarFile;
   private final ZipFile file;
-  private boolean isJar;
+  private final boolean isZip;
 
   @SuppressWarnings("deprecation")
   JarContextSource(final IBytecodeProvider legacyProvider, final File archive) throws IOException {
@@ -43,7 +39,7 @@ final class JarContextSource implements IContextSource, AutoCloseable {
     this.relativePath = relativePath;
     this.jarFile = requireNonNull(archive, "archive");
     this.file = new ZipFile(archive);
-    this.isJar = this.jarFile.getName().endsWith("jar");
+    this.isZip = this.jarFile.getName().endsWith("zip");
   }
 
   @Override
@@ -67,7 +63,7 @@ final class JarContextSource implements IContextSource, AutoCloseable {
         if (name.endsWith(CLASS_SUFFIX)) {
           classes.add(Entry.parse(name.substring(0, name.length() - CLASS_SUFFIX.length())));
         }
-        else if (!this.isJar || !name.equalsIgnoreCase(MANIFEST)) {
+        else if (this.isZip || !name.equalsIgnoreCase(MANIFEST)) {
           others.add(Entry.parse(name));
         }
       }

--- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
+++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
@@ -2,10 +2,10 @@
 package org.jetbrains.java.decompiler.struct;
 
 import org.jetbrains.java.decompiler.main.DecompilerContext;
-import org.jetbrains.java.decompiler.main.extern.IResultSaver;
 import org.jetbrains.java.decompiler.main.extern.IBytecodeProvider;
 import org.jetbrains.java.decompiler.main.extern.IContextSource;
 import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
+import org.jetbrains.java.decompiler.main.extern.IResultSaver;
 import org.jetbrains.java.decompiler.struct.gen.generics.GenericMain;
 import org.jetbrains.java.decompiler.struct.gen.generics.GenericMethodDescriptor;
 import org.jetbrains.java.decompiler.util.DataInputFullStream;
@@ -14,11 +14,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -124,28 +124,53 @@ public class StructContext {
     }
   }
 
+  private static boolean isJarFile(File file) {
+    if (!file.isFile()) return false;
+    String name = file.getName();
+    if (name.endsWith(".jar") || name.endsWith(".zip")) return true;
+    if (name.endsWith(".class")) return false;
+    try (SeekableByteChannel channel = Files.newByteChannel(file.toPath())) {
+      long size = channel.size();
+      // The EOCD ZIP record has 22+n bytes depending on the length of the comment.
+      if (size < 22) return false;
+      int bufferSize = (int) Math.min(size & ~3, 1024);
+      channel.position(size - bufferSize);
+      ByteBuffer buffer = ByteBuffer.allocate(bufferSize).order(ByteOrder.LITTLE_ENDIAN);
+      int read = 0;
+      while (read < bufferSize) {
+        read += channel.read(buffer);
+      }
+      buffer.flip();
+      for (int pos = buffer.limit() - 22; pos >= 0; pos--) {
+        if (buffer.getInt(pos) == 0x06054b50) {
+          return true;
+        }
+      }
+    } catch (IOException e) {
+      DecompilerContext.getLogger().writeMessage("Could not determine if " + file + " contains a JAR file", IFernflowerLogger.Severity.WARN, e);
+    }
+    return false;
+  }
+
   public void addSpace(File file, boolean isOwn) {
     if (file.isDirectory()) {
       addSpace(new DirectoryContextSource(this.legacyProvider, file), isOwn);
+    } else if (isJarFile(file)) {
+      // archive
+      try {
+        addSpace(new JarContextSource(this.legacyProvider, file), isOwn);
+      } catch (final IOException ex) {
+        final String message = "Invalid archive " + file;
+        DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.ERROR, ex);
+        throw new UncheckedIOException(message, ex);
+      }
     } else if (file.isFile()) {
-      final String name = file.getName();
-      if (name.endsWith(".jar") || name.endsWith(".zip")) {
-        // archive
-        try {
-          addSpace(new JarContextSource(this.legacyProvider, file), isOwn);
-        } catch (final IOException ex) {
-          final String message = "Invalid archive " + file;
-          DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.ERROR, ex);
-          throw new UncheckedIOException(message, ex);
-        }
-      } else {
-        try {
-          addSpace(new SingleFileContextSource(this.legacyProvider, file), isOwn);
-        } catch (final IOException ex) {
-          final String message = "Invalid file " + file;
-          DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.ERROR, ex);
-          throw new UncheckedIOException(message, ex);
-        }
+      try {
+        addSpace(new SingleFileContextSource(this.legacyProvider, file), isOwn);
+      } catch (final IOException ex) {
+        final String message = "Invalid file " + file;
+        DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.ERROR, ex);
+        throw new UncheckedIOException(message, ex);
       }
     }
   }


### PR DESCRIPTION
This handles for example self-executing JARs packaged as EXE file,
which contain the JAR content at the end after the native code.

These files are treated like JAR files, meaning any MANIFEST.MF will
not be extracted.