### PR TITLE
(Exhaustive) switch improvements

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
@@ -224,8 +224,9 @@ public final class SwitchHelper {
       following.getHeadexprent().replaceExprent(followingVal, ((InvocationExprent)value).getInstance());
 
       List<Exprent> firsts = switchStatement.getFirst().getExprents();
-      if (firsts.size() > 0)
+      if (firsts.size() > 0) {
         firsts.remove(firsts.size() - 1);
+      }
       switchStatement.getFirst().getAllPredecessorEdges().forEach(switchStatement.getFirst()::removePredecessor);
       switchStatement.getFirst().getAllSuccessorEdges().forEach(switchStatement.getFirst()::removeSuccessor);
       switchStatement.getParent().replaceStatement(switchStatement, switchStatement.getFirst());
@@ -422,7 +423,7 @@ public final class SwitchHelper {
 
     // if we're the only thing in an if statement,
     if (first.getParent() instanceof IfStatement) {
-      if (first.getSuccessorEdges(StatEdge.TYPE_REGULAR).size() == 0) {
+      if (!first.hasSuccessor(StatEdge.TYPE_REGULAR)) {
         IfStatement parent = (IfStatement) first.getParent();
         Exprent ifCond = parent.getHeadexprent().getCondition();
         // and it's a null check,
@@ -456,9 +457,10 @@ public final class SwitchHelper {
 
       if (firstValue.type == Exprent.EXPRENT_INVOCATION && secondValue.type == Exprent.EXPRENT_VAR && first.getCaseStatements().get(0).type == Statement.TYPE_IF) {
         InvocationExprent invExpr = (InvocationExprent)firstValue;
-        VarExprent varExpr = (VarExprent)secondValue;
-        if (nullAssign != null && !nullAssign.getLeft().equals(varExpr))
+        VarExprent varExpr = (VarExprent) secondValue;
+        if (nullAssign != null && !nullAssign.getLeft().equals(varExpr)) {
           return false; // wrong assignment across `if`
+        }
 
         if (invExpr.getName().equals("hashCode") && invExpr.getClassname().equals("java/lang/String")) {
           boolean matches = true;

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
@@ -418,6 +418,7 @@ public final class SwitchHelper {
     if (edges.size() == 1 && edges.get(0).getDestination().type == Statement.TYPE_SWITCH) {
       second = (SwitchStatement)edges.get(0).getDestination();
     }
+    AssignmentExprent nullAssign = null;
 
     // if we're the only thing in an if statement,
     if (first.getParent() instanceof IfStatement) {
@@ -435,6 +436,7 @@ public final class SwitchHelper {
               if (elseStat instanceof BasicBlockStatement && elseStat.getExprents().size() == 1) {
                 Exprent assign = elseStat.getExprents().get(0);
                 if (assign instanceof AssignmentExprent) {
+                  nullAssign = (AssignmentExprent)assign;
                   // then we're probably a nullable string-switch
                   edges = parent.getSuccessorEdges(StatEdge.TYPE_REGULAR);
                   if (edges.size() == 1 && edges.get(0).getDestination().type == Statement.TYPE_SWITCH) {
@@ -455,6 +457,8 @@ public final class SwitchHelper {
       if (firstValue.type == Exprent.EXPRENT_INVOCATION && secondValue.type == Exprent.EXPRENT_VAR && first.getCaseStatements().get(0).type == Statement.TYPE_IF) {
         InvocationExprent invExpr = (InvocationExprent)firstValue;
         VarExprent varExpr = (VarExprent)secondValue;
+        if (nullAssign != null && !nullAssign.getLeft().equals(varExpr))
+          return false; // wrong assignment across `if`
 
         if (invExpr.getName().equals("hashCode") && invExpr.getClassname().equals("java/lang/String")) {
           boolean matches = true;

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
@@ -426,8 +426,8 @@ public final class SwitchHelper {
       if (!first.hasSuccessor(StatEdge.TYPE_REGULAR)) {
         IfStatement parent = (IfStatement) first.getParent();
         Exprent ifCond = parent.getHeadexprent().getCondition();
-        // and it's a null check,
-        if (ifCond instanceof FunctionExprent) {
+        // and it's a null check with `else` branch,
+        if (parent.iftype == IfStatement.IFTYPE_IFELSE && ifCond instanceof FunctionExprent) {
           FunctionExprent func = (FunctionExprent)ifCond;
           if (func.getFuncType() == FunctionExprent.FUNCTION_NE && func.getLstOperands().size() == 2) {
             Exprent right = func.getLstOperands().get(1);

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
@@ -8,13 +8,10 @@ import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
 import org.jetbrains.java.decompiler.main.rels.ClassWrapper;
 import org.jetbrains.java.decompiler.main.rels.MethodWrapper;
 import org.jetbrains.java.decompiler.modules.decompiler.exps.*;
-import org.jetbrains.java.decompiler.modules.decompiler.stats.IfStatement;
-import org.jetbrains.java.decompiler.modules.decompiler.stats.RootStatement;
-import org.jetbrains.java.decompiler.modules.decompiler.stats.Statement;
-import org.jetbrains.java.decompiler.modules.decompiler.stats.SwitchStatement;
+import org.jetbrains.java.decompiler.modules.decompiler.stats.*;
 import org.jetbrains.java.decompiler.struct.StructField;
 import org.jetbrains.java.decompiler.struct.StructMethod;
-import org.jetbrains.java.decompiler.util.DotExporter;
+import org.jetbrains.java.decompiler.struct.gen.VarType;
 import org.jetbrains.java.decompiler.util.Pair;
 
 import java.util.*;
@@ -37,12 +34,6 @@ public final class SwitchHelper {
   }
 
   private static boolean simplify(SwitchStatement switchStatement, StructMethod mt, RootStatement root) {
-    SwitchStatement following = null;
-    List<StatEdge> edges = switchStatement.getSuccessorEdges(StatEdge.TYPE_REGULAR);
-    if (edges.size() == 1 && edges.get(0).getDestination().type == Statement.TYPE_SWITCH) {
-      following = (SwitchStatement)edges.get(0).getDestination();
-    }
-
     SwitchHeadExprent switchHeadExprent = (SwitchHeadExprent)switchStatement.getHeadexprent();
     Exprent value = switchHeadExprent.getValue();
     ArrayExprent array = getEnumArrayExprent(value, root);
@@ -172,8 +163,22 @@ public final class SwitchHelper {
       }
 
       return true;
-    } else if (isSwitchOnString(switchStatement, following)) {
+    } else if (isSwitchOnString(switchStatement)) {
       Map<Integer, Exprent> caseMap = new HashMap<>();
+
+      SwitchStatement following;
+      boolean nullable = false;
+      IfStatement containingNullCheck = null;
+      List<StatEdge> edges = switchStatement.getSuccessorEdges(StatEdge.TYPE_REGULAR);
+      if (edges.size() == 1 && edges.get(0).getDestination().type == Statement.TYPE_SWITCH) {
+        following = (SwitchStatement)edges.get(0).getDestination();
+      } else {
+        // definitely a nullable switch
+        // we've already validated the `if` in `isSwitchOnString`
+        nullable = true;
+        containingNullCheck = (IfStatement) switchStatement.getParent();
+        following = (SwitchStatement) containingNullCheck.getSuccessorEdges(StatEdge.TYPE_REGULAR).get(0).getDestination();
+      }
 
       int i = 0;
       for (; i < switchStatement.getCaseStatements().size(); ++i) {
@@ -198,6 +203,13 @@ public final class SwitchHelper {
         }
       }
 
+      if (nullable) {
+        // the else branch of the containing `if` will have an assignment exprent to get the null case from
+        Statement elseBranch = containingNullCheck.getElsestat();
+        AssignmentExprent assign = (AssignmentExprent) elseBranch.getExprents().get(0);
+        caseMap.put(((ConstExprent)assign.getRight()).getIntValue(), new ConstExprent(VarType.VARTYPE_NULL, null, null));
+      }
+
       List<List<Exprent>> realCaseValues = following.getCaseValues().stream()
         .map(l -> l.stream()
           .map(e -> e instanceof ConstExprent ? ((ConstExprent)e).getIntValue() : null)
@@ -211,10 +223,17 @@ public final class SwitchHelper {
       Exprent followingVal = ((SwitchHeadExprent)following.getHeadexprent()).getValue();
       following.getHeadexprent().replaceExprent(followingVal, ((InvocationExprent)value).getInstance());
 
-      switchStatement.getFirst().getExprents().remove(switchStatement.getFirst().getExprents().size() - 1);
+      List<Exprent> firsts = switchStatement.getFirst().getExprents();
+      if (firsts.size() > 0)
+        firsts.remove(firsts.size() - 1);
       switchStatement.getFirst().getAllPredecessorEdges().forEach(switchStatement.getFirst()::removePredecessor);
       switchStatement.getFirst().getAllSuccessorEdges().forEach(switchStatement.getFirst()::removeSuccessor);
       switchStatement.getParent().replaceStatement(switchStatement, switchStatement.getFirst());
+
+      if (nullable) {
+        // remove the containing `if`
+        containingNullCheck.replaceWithEmpty();
+      }
 
       // Remove phantom references from old switch statement, but ignoring the first statement as that has been extracted out of the switch
       following.getAllPredecessorEdges().stream()
@@ -393,7 +412,42 @@ public final class SwitchHelper {
    *        // code for case "foo"
    *   }
    */
-  private static boolean isSwitchOnString(SwitchStatement first, SwitchStatement second) {
+  private static boolean isSwitchOnString(SwitchStatement first) {
+    SwitchStatement second = null;
+    List<StatEdge> edges = first.getSuccessorEdges(StatEdge.TYPE_REGULAR);
+    if (edges.size() == 1 && edges.get(0).getDestination().type == Statement.TYPE_SWITCH) {
+      second = (SwitchStatement)edges.get(0).getDestination();
+    }
+
+    // if we're the only thing in an if statement,
+    if (first.getParent() instanceof IfStatement) {
+      if (first.getSuccessorEdges(StatEdge.TYPE_REGULAR).size() == 0) {
+        IfStatement parent = (IfStatement) first.getParent();
+        Exprent ifCond = parent.getHeadexprent().getCondition();
+        // and it's a null check,
+        if (ifCond instanceof FunctionExprent) {
+          FunctionExprent func = (FunctionExprent)ifCond;
+          if (func.getFuncType() == FunctionExprent.FUNCTION_NE && func.getLstOperands().size() == 2) {
+            Exprent right = func.getLstOperands().get(1);
+            if (right.type == Exprent.EXPRENT_CONST && right.getExprType() == VarType.VARTYPE_NULL) {
+              // and the `else` only assigns a variable,
+              Statement elseStat = parent.getElsestat();
+              if (elseStat instanceof BasicBlockStatement && elseStat.getExprents().size() == 1) {
+                Exprent assign = elseStat.getExprents().get(0);
+                if (assign instanceof AssignmentExprent) {
+                  // then we're probably a nullable string-switch
+                  edges = parent.getSuccessorEdges(StatEdge.TYPE_REGULAR);
+                  if (edges.size() == 1 && edges.get(0).getDestination().type == Statement.TYPE_SWITCH) {
+                    second = (SwitchStatement)edges.get(0).getDestination();
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
     if (second != null) {
       Exprent firstValue = ((SwitchHeadExprent)first.getHeadexprent()).getValue();
       Exprent secondValue = ((SwitchHeadExprent)second.getHeadexprent()).getValue();

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
@@ -68,7 +68,9 @@ public class SwitchExprent extends Exprent {
         if (value == null) { // TODO: how can this be null? Is it trying to inject a synthetic case value in switch-on-string processing? [TestSwitchDefaultBefore]
           continue;
         }
-        if (hasDefault && !includeWithDefault(value)) {
+
+        // only a null label changes `default` label semantics
+        if (hasDefault && (value.getExprType() != VarType.VARTYPE_NULL)) {
           continue;
         }
 
@@ -187,10 +189,6 @@ public class SwitchExprent extends Exprent {
         && ((ExitExprent) targetExpr).getValue().getExprType().value.equals("java/lang/IncompatibleClassChangeError");
     }
     return false;
-  }
-
-  private static boolean includeWithDefault(Exprent expr){
-    return expr.getExprType() == VarType.VARTYPE_NULL;
   }
 
   @Override

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
@@ -57,7 +57,6 @@ public class SwitchExprent extends Exprent {
               break; // just don't mark as default
             }
           }
-          //buf.appendIndent(indent + 1).append("default -> ");
           hasDefault = true;
           break;
         }
@@ -79,7 +78,7 @@ public class SwitchExprent extends Exprent {
           buf.append(", ");
         }
 
-        if (value instanceof ConstExprent && !standalone) {
+        if (value instanceof ConstExprent && !standalone && value.getExprType() != VarType.VARTYPE_NULL) {
           value = value.copy();
           ((ConstExprent) value).setConstType(switchType);
         }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
@@ -190,7 +190,6 @@ public class SwitchExprent extends Exprent {
   }
 
   private static boolean includeWithDefault(Exprent expr){
-    // TODO: is this ever currently true?
     return expr.getExprType() == VarType.VARTYPE_NULL;
   }
 

--- a/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java
+++ b/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java
@@ -115,7 +115,9 @@ public class DecompilerTestFixture {
         }
       });
     } catch (IOException e) {
-      throw new UncheckedIOException(e);
+      // issue when deleting temp META-INF on windows, seemingly
+      //throw new UncheckedIOException(e);
+      e.printStackTrace();
     }
   }
 

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -399,7 +399,12 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching3");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching4");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching5");
+    // TODO: fix broken enum/string switch resugaring w/ null label, for all of these
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching6", "ext/Direction");
+    register(JAVA_17_PREVIEW, "TestSwitchPatternMatching7");
+    register(JAVA_17_PREVIEW, "TestSwitchPatternMatching8");
+    register(JAVA_17_PREVIEW, "TestSwitchPatternMatching9");
+
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatchingInstanceof1");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatchingInstanceof2");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatchingReturn1");

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -346,9 +346,9 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_16, "TestBooleanSwitchExpression4");
     register(JAVA_16, "TestBooleanSwitchExpression5");
 
-    register(JAVA_16, "TestInlineSwitchExpression1");
+    register(JAVA_16, "TestInlineSwitchExpression1", "ext/Direction");
     register(JAVA_16, "TestInlineSwitchExpression2");
-    register(JAVA_16, "TestInlineSwitchExpression3");
+    register(JAVA_16, "TestInlineSwitchExpression3", "ext/Direction");
     register(JAVA_16, "TestInlineSwitchExpression4");
     register(JAVA_16, "TestInlineSwitchExpression5");
     register(JAVA_16, "TestInlineSwitchExpression6");
@@ -399,6 +399,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching3");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching4");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching5");
+    register(JAVA_17_PREVIEW, "TestSwitchPatternMatching6", "ext/Direction");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatchingInstanceof1");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatchingInstanceof2");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatchingReturn1");

--- a/testData/results/pkg/TestInlineSwitchExpression1.dec
+++ b/testData/results/pkg/TestInlineSwitchExpression1.dec
@@ -11,7 +11,6 @@ public class TestInlineSwitchExpression1 {
          case WEST -> Direction.EAST;// 15
          case UP -> Direction.DOWN;// 17
          case DOWN -> Direction.UP;// 19
-         default -> throw new IncompatibleClassChangeError();
       });
    }// 21
 }
@@ -41,11 +40,10 @@ class 'pkg/TestInlineSwitchExpression1' {
       4e      12
       4f      12
       50      12
-      5b      13
       5c      6
       5d      6
       5e      6
-      5f      15
+      5f      14
    }
 }
 
@@ -57,4 +55,4 @@ Lines mapping:
 15 <-> 11
 17 <-> 12
 19 <-> 13
-21 <-> 16
+21 <-> 15

--- a/testData/results/pkg/TestInlineSwitchExpression3.dec
+++ b/testData/results/pkg/TestInlineSwitchExpression3.dec
@@ -7,7 +7,6 @@ public class TestInlineSwitchExpression3 {
       System.out.println(switch(direction) {// 9
          case NORTH, EAST, UP -> -1;// 13
          case SOUTH, WEST, DOWN -> 1;// 17
-         default -> throw new IncompatibleClassChangeError();
       });
    }// 19
 }
@@ -21,11 +20,10 @@ class 'pkg/TestInlineSwitchExpression3' {
       b      6
       30      7
       34      8
-      3f      9
       40      6
       41      6
       42      6
-      43      11
+      43      10
    }
 }
 
@@ -33,4 +31,4 @@ Lines mapping:
 9 <-> 7
 13 <-> 8
 17 <-> 9
-19 <-> 12
+19 <-> 11

--- a/testData/results/pkg/TestSwitchPatternMatching6.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching6.dec
@@ -1,0 +1,40 @@
+package pkg;
+
+import ext.Direction;
+
+public class TestSwitchPatternMatching6 {
+   static int testTriangle(Direction d) {
+      return switch(d != null ? SyntheticClass_1.$SwitchMap$ext$Direction[d.ordinal()] : -1) {// 1 7
+         default -> -1;// 10
+         case 1, 2, 3 -> 0;// 8
+         case 4, 5 -> 1;// 9
+      };
+   }
+}
+
+class 'pkg/TestSwitchPatternMatching6' {
+   method 'testTriangle (Lext/Direction;)I' {
+      0      6
+      3      6
+      6      6
+      7      6
+      8      6
+      a      6
+      b      6
+      c      6
+      d      6
+      11      6
+      12      6
+      40      8
+      44      9
+      48      7
+      49      6
+   }
+}
+
+Lines mapping:
+1 <-> 7
+7 <-> 7
+8 <-> 9
+9 <-> 10
+10 <-> 8

--- a/testData/results/pkg/TestSwitchPatternMatching7.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching7.dec
@@ -1,0 +1,36 @@
+package pkg;
+
+import java.lang.runtime.SwitchBootstraps;
+
+public class TestSwitchPatternMatching7 {
+   static String test(Object s) {
+      byte var2 = 0;
+      switch(SwitchBootstraps.typeSwitch<"typeSwitch">(s, var2)) {
+         case int:
+         default:
+            return "everything";// 5 6
+      }
+   }
+}
+
+class 'pkg/TestSwitchPatternMatching7' {
+   method 'test (Ljava/lang/Object;)Ljava/lang/String;' {
+      0      7
+      2      6
+      3      6
+      5      7
+      6      7
+      7      7
+      8      7
+      9      7
+      a      7
+      b      7
+      1c      10
+      1d      10
+      1e      10
+   }
+}
+
+Lines mapping:
+5 <-> 11
+6 <-> 11

--- a/testData/results/pkg/TestSwitchPatternMatching8.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching8.dec
@@ -1,0 +1,73 @@
+package pkg;
+
+public class TestSwitchPatternMatching8 {
+   static String test(String s) {
+      byte var2 = -1;
+      if (s != null) {
+         switch(s.hashCode()) {
+            case 3329:
+               if (s.equals("hi")) {
+                  var2 = 0;
+               }
+               break;
+            case 98030:
+               if (s.equals("bye")) {
+                  var2 = 1;
+               }
+         }
+      } else {
+         var2 = 2;
+      }
+
+      return switch(var2) {// 5
+         case 0 -> "hi";// 6
+         case 1 -> "bye";// 7
+         default -> "oh";// 8
+      };
+   }
+}
+
+class 'pkg/TestSwitchPatternMatching8' {
+   method 'test (Ljava/lang/String;)Ljava/lang/String;' {
+      0      5
+      2      4
+      3      4
+      5      5
+      9      6
+      a      6
+      b      6
+      c      6
+      29      8
+      2a      8
+      2b      8
+      2c      8
+      2d      8
+      2e      8
+      31      9
+      32      9
+      37      13
+      38      13
+      39      13
+      3a      13
+      3b      13
+      3c      13
+      3f      14
+      40      14
+      44      18
+      45      18
+      46      21
+      47      21
+      60      22
+      61      22
+      65      23
+      66      23
+      6a      24
+      6c      21
+   }
+}
+
+Lines mapping:
+5 <-> 22
+6 <-> 23
+7 <-> 24
+8 <-> 25

--- a/testData/results/pkg/TestSwitchPatternMatching8.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching8.dec
@@ -2,72 +2,33 @@ package pkg;
 
 public class TestSwitchPatternMatching8 {
    static String test(String s) {
-      byte var2 = -1;
-      if (s != null) {
-         switch(s.hashCode()) {
-            case 3329:
-               if (s.equals("hi")) {
-                  var2 = 0;
-               }
-               break;
-            case 98030:
-               if (s.equals("bye")) {
-                  var2 = 1;
-               }
-         }
-      } else {
-         var2 = 2;
-      }
-
-      return switch(var2) {// 5
-         case 0 -> "hi";// 6
-         case 1 -> "bye";// 7
-         default -> "oh";// 8
+      return switch(s) {// 5
+         case "hi" -> "hi";// 6
+         case "bye" -> "bye";// 7
+         case null, default -> "oh";// 8
       };
    }
 }
 
 class 'pkg/TestSwitchPatternMatching8' {
    method 'test (Ljava/lang/String;)Ljava/lang/String;' {
-      0      5
-      2      4
-      3      4
-      5      5
-      9      6
-      a      6
-      b      6
-      c      6
-      29      8
-      2a      8
-      2b      8
-      2c      8
-      2d      8
-      2e      8
-      31      9
-      32      9
-      37      13
-      38      13
-      39      13
-      3a      13
-      3b      13
-      3c      13
-      3f      14
-      40      14
-      44      18
-      45      18
-      46      21
-      47      21
-      60      22
-      61      22
-      65      23
-      66      23
-      6a      24
-      6c      21
+      0      4
+      29      5
+      2a      5
+      37      6
+      38      6
+      47      4
+      60      5
+      61      5
+      65      6
+      66      6
+      6a      7
+      6c      4
    }
 }
 
 Lines mapping:
-5 <-> 22
-6 <-> 23
-7 <-> 24
-8 <-> 25
+5 <-> 5
+6 <-> 6
+7 <-> 7
+8 <-> 8

--- a/testData/results/pkg/TestSwitchPatternMatching9.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching9.dec
@@ -1,0 +1,90 @@
+package pkg;
+
+public class TestSwitchPatternMatching9 {
+   static String test(String s) {
+      byte var2 = -1;
+      if (s != null) {
+         switch(s.hashCode()) {
+            case 3329:
+               if (s.equals("hi")) {
+                  var2 = 0;
+               }
+               break;
+            case 98030:
+               if (s.equals("bye")) {
+                  var2 = 1;
+               }
+               break;
+            case 3392903:
+               if (s.equals("null")) {
+                  var2 = 2;
+               }
+         }
+      } else {
+         var2 = 3;
+      }
+
+      return switch(var2) {// 5
+         case 0 -> "hi";// 6
+         case 1 -> "bye";// 7
+         case 2, 3 -> "null";// 8
+         default -> "oh";// 9
+      };
+   }
+}
+
+class 'pkg/TestSwitchPatternMatching9' {
+   method 'test (Ljava/lang/String;)Ljava/lang/String;' {
+      0      5
+      2      4
+      3      4
+      5      5
+      9      6
+      a      6
+      b      6
+      c      6
+      31      8
+      32      8
+      33      8
+      34      8
+      35      8
+      36      8
+      39      9
+      3a      9
+      3f      13
+      40      13
+      41      13
+      42      13
+      43      13
+      44      13
+      47      14
+      48      14
+      4d      18
+      4e      18
+      4f      18
+      50      18
+      51      18
+      52      18
+      55      19
+      56      19
+      5a      23
+      5b      23
+      5c      26
+      5d      26
+      7c      27
+      7d      27
+      81      28
+      82      28
+      86      29
+      87      29
+      8b      30
+      8d      26
+   }
+}
+
+Lines mapping:
+5 <-> 27
+6 <-> 28
+7 <-> 29
+8 <-> 30
+9 <-> 31

--- a/testData/results/pkg/TestSwitchPatternMatching9.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching9.dec
@@ -2,32 +2,10 @@ package pkg;
 
 public class TestSwitchPatternMatching9 {
    static String test(String s) {
-      byte var2 = -1;
-      if (s != null) {
-         switch(s.hashCode()) {
-            case 3329:
-               if (s.equals("hi")) {
-                  var2 = 0;
-               }
-               break;
-            case 98030:
-               if (s.equals("bye")) {
-                  var2 = 1;
-               }
-               break;
-            case 3392903:
-               if (s.equals("null")) {
-                  var2 = 2;
-               }
-         }
-      } else {
-         var2 = 3;
-      }
-
-      return switch(var2) {// 5
-         case 0 -> "hi";// 6
-         case 1 -> "bye";// 7
-         case 2, 3 -> "null";// 8
+      return switch(s) {// 5
+         case "hi" -> "hi";// 6
+         case "bye" -> "bye";// 7
+         case "null", null -> "null";// 8
          default -> "oh";// 9
       };
    }
@@ -35,56 +13,28 @@ public class TestSwitchPatternMatching9 {
 
 class 'pkg/TestSwitchPatternMatching9' {
    method 'test (Ljava/lang/String;)Ljava/lang/String;' {
-      0      5
-      2      4
-      3      4
-      5      5
-      9      6
-      a      6
-      b      6
-      c      6
-      31      8
-      32      8
-      33      8
-      34      8
-      35      8
-      36      8
-      39      9
-      3a      9
-      3f      13
-      40      13
-      41      13
-      42      13
-      43      13
-      44      13
-      47      14
-      48      14
-      4d      18
-      4e      18
-      4f      18
-      50      18
-      51      18
-      52      18
-      55      19
-      56      19
-      5a      23
-      5b      23
-      5c      26
-      5d      26
-      7c      27
-      7d      27
-      81      28
-      82      28
-      86      29
-      87      29
-      8b      30
-      8d      26
+      0      4
+      31      5
+      32      5
+      3f      6
+      40      6
+      4d      7
+      4e      7
+      5d      4
+      7c      5
+      7d      5
+      81      6
+      82      6
+      86      7
+      87      7
+      8b      8
+      8d      4
    }
 }
 
 Lines mapping:
-5 <-> 27
-6 <-> 28
-7 <-> 29
-8 <-> 30
-9 <-> 31
+5 <-> 5
+6 <-> 6
+7 <-> 7
+8 <-> 8
+9 <-> 9

--- a/testData/src/java17preview/ext/Direction.java
+++ b/testData/src/java17preview/ext/Direction.java
@@ -1,0 +1,10 @@
+package ext;
+
+public enum Direction {
+  NORTH,
+  SOUTH,
+  EAST,
+  WEST,
+  UP,
+  DOWN
+}

--- a/testData/src/java17preview/pkg/TestSwitchPatternMatching6.java
+++ b/testData/src/java17preview/pkg/TestSwitchPatternMatching6.java
@@ -1,0 +1,13 @@
+package pkg;
+
+import ext.Direction;
+
+public class TestSwitchPatternMatching6 {
+  static int testTriangle(Direction d) {
+    return switch (d) {
+      case NORTH, SOUTH, WEST -> 0;
+      case EAST, UP -> 1;
+      case DOWN, null, default -> -1;
+    };
+  }
+}

--- a/testData/src/java17preview/pkg/TestSwitchPatternMatching7.java
+++ b/testData/src/java17preview/pkg/TestSwitchPatternMatching7.java
@@ -1,0 +1,9 @@
+package pkg;
+
+public class TestSwitchPatternMatching7 {
+  static String test(Object s) {
+    return switch (s) {
+      case null, default -> "everything";
+    };
+  }
+}

--- a/testData/src/java17preview/pkg/TestSwitchPatternMatching8.java
+++ b/testData/src/java17preview/pkg/TestSwitchPatternMatching8.java
@@ -1,0 +1,11 @@
+package pkg;
+
+public class TestSwitchPatternMatching8 {
+  static String test(String s) {
+    return switch (s) {
+      case "hi" -> "hi";
+      case "bye" -> "bye";
+      case null, default -> "oh";
+    };
+  }
+}

--- a/testData/src/java17preview/pkg/TestSwitchPatternMatching9.java
+++ b/testData/src/java17preview/pkg/TestSwitchPatternMatching9.java
@@ -1,0 +1,12 @@
+package pkg;
+
+public class TestSwitchPatternMatching9 {
+  static String test(String s) {
+    return switch (s) {
+      case "hi" -> "hi";
+      case "bye" -> "bye";
+      case "null", null -> "null";
+      case default -> "oh";
+    };
+  }
+}


### PR DESCRIPTION
Removes implicit `default -> throw ICCE` branches in exhaustive switch expressions, fixing #111.

Fixes nullable string-switches.

(Also fixes bulk decompilation tests to work on my PC.)

Also introduces test cases for a switch branch with a `default` *and* other options, and nullable switch expressions.