### PR TITLE
Switch fixes

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
@@ -124,6 +124,7 @@ public final class SwitchHelper {
       for (List<Exprent> caseValue : caseValues) {
         List<Exprent> values = new ArrayList<>(caseValue.size());
         realCaseValues.add(values);
+        cases:
         for (Exprent exprent : caseValue) {
           if (exprent == null) {
             values.add(null);
@@ -131,6 +132,28 @@ public final class SwitchHelper {
           else {
             Exprent realConst = mapping.get(exprent);
             if (realConst == null) {
+              if (exprent instanceof ConstExprent) {
+                ConstExprent constLabel = (ConstExprent) exprent;
+                if (constLabel.getConstType().typeFamily == CodeConstants.TYPE_FAMILY_INTEGER) {
+                  int intLabel = constLabel.getIntValue();
+                  // check for -1, used by nullable switches for the null branch
+                  if (intLabel == -1) {
+                    values.add(new ConstExprent(VarType.VARTYPE_NULL, null, null));
+                    continue;
+                  }
+                  // other values can show up in a `tableswitch`, such as in [-1, fall-through synthetic 0, 1, 2, ...]
+                  // they must have a valid value later though
+                  // TODO: more tests
+                  for (Exprent key : mapping.keySet()) {
+                    if (key instanceof ConstExprent
+                        && ((ConstExprent) key).getConstType().typeFamily == CodeConstants.TYPE_FAMILY_INTEGER
+                        && ((ConstExprent) key).getIntValue() > intLabel) {
+                      values.add(key.copy());
+                      continue cases;
+                    }
+                  }
+                }
+              }
               root.addComment("$FF: Unable to simplify switch on enum");
               root.addErrorComment = true;
               DecompilerContext.getLogger()
@@ -288,14 +311,14 @@ public final class SwitchHelper {
           return false;
         }
 
-        boolean isSyncheticClass;
+        boolean isSyntheticClass;
         if (classNode.getWrapper() == null) {
-          isSyncheticClass = (classNode.classStruct.getAccessFlags() & CodeConstants.ACC_SYNTHETIC) == CodeConstants.ACC_SYNTHETIC;
+          isSyntheticClass = (classNode.classStruct.getAccessFlags() & CodeConstants.ACC_SYNTHETIC) == CodeConstants.ACC_SYNTHETIC;
         } else {
-          isSyncheticClass = (classNode.getWrapper().getClassStruct().getAccessFlags() & CodeConstants.ACC_SYNTHETIC) == CodeConstants.ACC_SYNTHETIC;
+          isSyntheticClass = (classNode.getWrapper().getClassStruct().getAccessFlags() & CodeConstants.ACC_SYNTHETIC) == CodeConstants.ACC_SYNTHETIC;
         }
 
-        if (isSyncheticClass) {
+        if (isSyntheticClass) {
           return true; //TODO: Find a way to check the structure of the initalizer?
           //Exprent init = classNode.getWrapper().getStaticFieldInitializers().getWithKey(InterpreterUtil.makeUniqueKey(field.getName(), field.getDescriptor().descriptorString));
           //Above is null because we haven't preocess the class yet?
@@ -317,6 +340,29 @@ public final class SwitchHelper {
    */
   private static ArrayExprent getEnumArrayExprent(Exprent switchHead, RootStatement root) {
     Exprent candidate = switchHead;
+
+    if (switchHead instanceof FunctionExprent) {
+      // Check for switches on a ternary expression like `a != null ? ...SwitchMap[a.ordinal()] : -1` (nullable switch)
+      FunctionExprent func = (FunctionExprent) switchHead;
+      if (func.getFuncType() == FunctionExprent.FUNCTION_TERNARY && func.getLstOperands().size() == 3) {
+        List<Exprent> ops = func.getLstOperands();
+        if (ops.get(0) instanceof FunctionExprent) {
+          FunctionExprent nn = (FunctionExprent) ops.get(0);
+          if (nn.getFuncType() == FunctionExprent.FUNCTION_NE
+                && nn.getLstOperands().get(0) instanceof VarExprent
+                && nn.getLstOperands().get(1).getExprType().equals(VarType.VARTYPE_NULL)) {
+            // TODO: consider if verifying the variable used is necessary
+            // probably not, since the array is checked to be generated (?) so user written code shouldn't encounter bad resugaring
+            if (ops.get(2) instanceof ConstExprent) {
+              ConstExprent minusOne = (ConstExprent) ops.get(2);
+              if (minusOne.getConstType().equals(VarType.VARTYPE_INT) && minusOne.getIntValue() == -1) {
+                candidate = ops.get(1);
+              }
+            }
+          }
+        }
+      }
+    }
 
     if (switchHead instanceof VarExprent) {
       // Check for switches with intermediary assignment of enum array index

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
@@ -345,11 +345,11 @@ public final class SwitchHelper {
     if (switchHead instanceof FunctionExprent) {
       // Check for switches on a ternary expression like `a != null ? ...SwitchMap[a.ordinal()] : -1` (nullable switch)
       FunctionExprent func = (FunctionExprent) switchHead;
-      if (func.getFuncType() == FunctionExprent.FUNCTION_TERNARY && func.getLstOperands().size() == 3) {
+      if (func.getFuncType() == FunctionExprent.FunctionType.TERNARY && func.getLstOperands().size() == 3) {
         List<Exprent> ops = func.getLstOperands();
         if (ops.get(0) instanceof FunctionExprent) {
           FunctionExprent nn = (FunctionExprent) ops.get(0);
-          if (nn.getFuncType() == FunctionExprent.FUNCTION_NE
+          if (nn.getFuncType() == FunctionExprent.FunctionType.NE
                 && nn.getLstOperands().get(0) instanceof VarExprent
                 && nn.getLstOperands().get(1).getExprType().equals(VarType.VARTYPE_NULL)) {
             // TODO: consider if verifying the variable used is necessary

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
@@ -411,8 +411,9 @@ public final class SwitchHelper {
    * @param onlyOneStat if true, will return eagerly after the first matching statement
    * @param consumer    the consumer that receives the exprents and their parent statements
    */
+  // TODO: move somewhere better
   @SuppressWarnings("unchecked")
-  private static <T extends Exprent> void findExprents(Statement start, Class<? extends T> exprClass, Predicate<T> predicate, boolean onlyOneStat, BiConsumer<Statement, T> consumer) {
+  public static <T extends Exprent> void findExprents(Statement start, Class<? extends T> exprClass, Predicate<T> predicate, boolean onlyOneStat, BiConsumer<Statement, T> consumer) {
     Queue<Statement> statQueue = new ArrayDeque<>();
     statQueue.offer(start);
 

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchPatternMatchProcessor.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchPatternMatchProcessor.java
@@ -140,12 +140,11 @@ public final class SwitchPatternMatchProcessor {
         suc.addSuccessor(new StatEdge(StatEdge.TYPE_REGULAR, suc, oldSuc, seq));
       }
 
-      head.setValue(((InvocationExprent)head.getValue()).getLstParameters().get(0));
-
       stat.setPhantom(true);
-
       suc.getExprents().add(0, new SwitchExprent(stat, VarType.VARTYPE_INT, false, true));
     }
+
+    head.setValue(((InvocationExprent)head.getValue()).getLstParameters().get(0));
 
     return false;
   }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
@@ -11,10 +11,7 @@ import org.jetbrains.java.decompiler.struct.StructField;
 import org.jetbrains.java.decompiler.struct.gen.VarType;
 import org.jetbrains.java.decompiler.util.TextBuffer;
 
-import java.util.BitSet;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 public class SwitchExprent extends Exprent {
   private final SwitchStatement backing;

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
@@ -80,7 +80,7 @@ public class SwitchExprent extends Exprent {
           buf.append(", ");
         }
 
-        if (value instanceof ConstExprent && !standalone && value.getExprType() != VarType.VARTYPE_NULL) {
+        if (value instanceof ConstExprent && !standalone && !Objects.equals(value.getExprType(), VarType.VARTYPE_NULL)) {
           value = value.copy();
           ((ConstExprent) value).setConstType(switchType);
         }
@@ -125,7 +125,7 @@ public class SwitchExprent extends Exprent {
         if (exprent.type == Exprent.EXPRENT_YIELD) {
           Exprent content = ((YieldExprent) exprent).getContent();
 
-          if (content.type == Exprent.EXPRENT_CONST) {
+          if (content.type == Exprent.EXPRENT_CONST && !Objects.equals(content.getExprType(), VarType.VARTYPE_NULL)) {
             ((ConstExprent)content).setConstType(this.type);
           }
 

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
@@ -157,7 +157,7 @@ public final class SwitchStatement extends Statement {
 
           buf.appendIndent(indent + 1).append("case ");
 
-          if (value instanceof ConstExprent) {
+          if (value instanceof ConstExprent && !value.getExprType().equals(VarType.VARTYPE_NULL)) {
             value = value.copy();
             ((ConstExprent)value).setConstType(switch_type);
           }

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -410,6 +410,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching9");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching10");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching11");
+    register(JAVA_17_PREVIEW, "TestSwitchPatternMatching12");
 
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatchingInstanceof1");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatchingInstanceof2");

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -403,8 +403,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching3");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching4");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching5");
-    // TODO: fix broken enum/string switch resugaring w/ null label, for all of these
-    // TODO: ternary in switch causes issues with switch detection
+    // null labels fall under Pattern Matching for Switch
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching6", "ext/Direction");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching7");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching8");

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -409,6 +409,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching7");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching8");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching9");
+    register(JAVA_17_PREVIEW, "TestSwitchPatternMatching10");
 
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatchingInstanceof1");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatchingInstanceof2");

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -410,6 +410,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching8");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching9");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatching10");
+    register(JAVA_17_PREVIEW, "TestSwitchPatternMatching11");
 
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatchingInstanceof1");
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatchingInstanceof2");

--- a/testData/results/pkg/TestSwitchPatternMatching1.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching1.dec
@@ -5,7 +5,6 @@ import java.util.Objects;
 public class TestSwitchPatternMatching1 {
    public void test(Object o) {
       Objects.requireNonNull(o);// 5
-      byte var3 = 0;
 
       switch(o) {
          case o instanceof Integer i -> System.out.println(i);// 6
@@ -21,42 +20,40 @@ class 'pkg/TestSwitchPatternMatching1' {
       2      6
       3      6
       4      6
-      7      7
-      8      7
-      10      9
-      30      10
-      31      10
-      32      10
-      33      10
-      34      10
-      35      10
-      36      10
-      37      10
-      38      10
-      39      10
-      41      11
-      42      11
-      43      11
-      44      11
-      45      11
-      46      11
-      47      11
-      48      11
-      49      11
-      4a      11
-      4e      12
-      4f      12
-      50      12
-      51      12
-      52      12
-      53      12
-      56      14
+      10      8
+      30      9
+      31      9
+      32      9
+      33      9
+      34      9
+      35      9
+      36      9
+      37      9
+      38      9
+      39      9
+      41      10
+      42      10
+      43      10
+      44      10
+      45      10
+      46      10
+      47      10
+      48      10
+      49      10
+      4a      10
+      4e      11
+      4f      11
+      50      11
+      51      11
+      52      11
+      53      11
+      56      13
    }
 }
 
 Lines mapping:
 5 <-> 7
-6 <-> 11
-7 <-> 12
-8 <-> 13
-10 <-> 15
+6 <-> 10
+7 <-> 11
+8 <-> 12
+10 <-> 14

--- a/testData/results/pkg/TestSwitchPatternMatching10.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching10.dec
@@ -1,0 +1,61 @@
+package pkg;
+
+public class TestSwitchPatternMatching10 {
+   static void test(String s) {
+      switch(s) {// 5
+         case "hi":
+            System.out.println("hi");// 6
+            break;
+         case "bye":
+            System.out.println("bye");// 7
+            break;
+         case null:
+         default:
+            System.out.println("oh");// 8
+      }
+
+   }// 10
+}
+
+class 'pkg/TestSwitchPatternMatching10' {
+   method 'test (Ljava/lang/String;)V' {
+      0      4
+      29      5
+      2a      5
+      37      8
+      38      8
+      47      4
+      60      6
+      61      6
+      62      6
+      63      6
+      64      6
+      65      6
+      66      6
+      67      6
+      68      7
+      6b      9
+      6c      9
+      6d      9
+      6e      9
+      6f      9
+      70      9
+      71      9
+      72      9
+      73      10
+      76      13
+      77      13
+      78      13
+      79      13
+      7a      13
+      7b      13
+      7e      16
+   }
+}
+
+Lines mapping:
+5 <-> 5
+6 <-> 7
+7 <-> 10
+8 <-> 14
+10 <-> 17

--- a/testData/results/pkg/TestSwitchPatternMatching11.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching11.dec
@@ -1,0 +1,37 @@
+package pkg;
+
+public class TestSwitchPatternMatching11 {
+   static String test(String s) {
+      return switch(s) {// 5
+         case "hi" -> "hi";// 6
+         case "bye" -> "bye";// 7
+         case null -> null;// 8
+         default -> "oh";// 9
+      };
+   }
+}
+
+class 'pkg/TestSwitchPatternMatching11' {
+   method 'test (Ljava/lang/String;)Ljava/lang/String;' {
+      0      4
+      29      5
+      2a      5
+      37      6
+      38      6
+      47      4
+      60      5
+      61      5
+      65      6
+      66      6
+      6a      7
+      6e      8
+      70      4
+   }
+}
+
+Lines mapping:
+5 <-> 5
+6 <-> 6
+7 <-> 7
+8 <-> 8
+9 <-> 9

--- a/testData/results/pkg/TestSwitchPatternMatching12.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching12.dec
@@ -1,0 +1,38 @@
+package pkg;
+
+import ext.Direction;
+
+public class TestSwitchPatternMatching12 {
+   static int testTriangle(boolean a, Direction l, Direction r) {
+      Direction var3 = a ? l : r;
+
+      return switch(var3) {// 1 7
+         case null, default -> -1;// 10
+         case NORTH, SOUTH, WEST -> 0;// 8
+         case EAST, UP -> 1;// 9
+      };
+   }
+}
+
+class 'pkg/TestSwitchPatternMatching12' {
+   method 'testTriangle (ZLext/Direction;Lext/Direction;)I' {
+      0      6
+      1      6
+      4      6
+      8      6
+      9      6
+      11      8
+      1a      8
+      48      10
+      4c      11
+      50      9
+      51      8
+   }
+}
+
+Lines mapping:
+1 <-> 9
+7 <-> 9
+8 <-> 11
+9 <-> 12
+10 <-> 10

--- a/testData/results/pkg/TestSwitchPatternMatching3.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching3.dec
@@ -2,8 +2,6 @@ package pkg;
 
 public class TestSwitchPatternMatching3 {
    static void test(Object s) {
-      byte var2 = 0;
-
       switch(s) {// 5
          case null -> System.out.println("null");// 7
          default -> System.out.println("default");// 9
@@ -13,30 +11,28 @@ public class TestSwitchPatternMatching3 {
 
 class 'pkg/TestSwitchPatternMatching3' {
    method 'test (Ljava/lang/Object;)V' {
-      0      6
-      2      4
-      3      4
-      b      6
-      1c      7
-      1d      7
-      1e      7
-      1f      7
-      20      7
-      21      7
-      22      7
-      23      7
-      27      8
-      28      8
-      29      8
-      2a      8
-      2b      8
-      2c      8
-      2f      10
+      0      4
+      b      4
+      1c      5
+      1d      5
+      1e      5
+      1f      5
+      20      5
+      21      5
+      22      5
+      23      5
+      27      6
+      28      6
+      29      6
+      2a      6
+      2b      6
+      2c      6
+      2f      8
    }
 }
 
 Lines mapping:
-5 <-> 7
-7 <-> 8
-9 <-> 9
-11 <-> 11
+5 <-> 5
+7 <-> 6
+9 <-> 7
+11 <-> 9

--- a/testData/results/pkg/TestSwitchPatternMatching4.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching4.dec
@@ -5,7 +5,6 @@ import java.util.Objects;
 public class TestSwitchPatternMatching4 {
    static void test(Object s) {
       Objects.requireNonNull(s);// 5
-      byte var2 = 0;
       switch(s) {
          default:
             System.out.println("default");// 7
@@ -19,22 +18,20 @@ class 'pkg/TestSwitchPatternMatching4' {
       2      6
       3      6
       4      6
-      7      7
-      8      7
-      10      8
-      1c      10
-      1d      10
-      1e      10
-      1f      10
-      20      10
-      21      10
-      22      10
-      23      10
-      24      12
+      10      7
+      1c      9
+      1d      9
+      1e      9
+      1f      9
+      20      9
+      21      9
+      22      9
+      23      9
+      24      11
    }
 }
 
 Lines mapping:
 5 <-> 7
-7 <-> 11
-9 <-> 13
+7 <-> 10
+9 <-> 12

--- a/testData/results/pkg/TestSwitchPatternMatching4.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching4.dec
@@ -1,13 +1,12 @@
 package pkg;
 
-import java.lang.runtime.SwitchBootstraps;
 import java.util.Objects;
 
 public class TestSwitchPatternMatching4 {
    static void test(Object s) {
       Objects.requireNonNull(s);// 5
       byte var2 = 0;
-      switch(SwitchBootstraps.typeSwitch<"typeSwitch">(s, var2)) {
+      switch(s) {
          default:
             System.out.println("default");// 7
       }
@@ -16,32 +15,26 @@ public class TestSwitchPatternMatching4 {
 
 class 'pkg/TestSwitchPatternMatching4' {
    method 'test (Ljava/lang/Object;)V' {
-      0      7
-      2      7
-      3      7
-      4      7
-      7      8
-      8      8
-      a      9
-      b      9
-      c      9
-      d      9
-      e      9
-      f      9
-      10      9
-      1c      11
-      1d      11
-      1e      11
-      1f      11
-      20      11
-      21      11
-      22      11
-      23      11
-      24      13
+      0      6
+      2      6
+      3      6
+      4      6
+      7      7
+      8      7
+      10      8
+      1c      10
+      1d      10
+      1e      10
+      1f      10
+      20      10
+      21      10
+      22      10
+      23      10
+      24      12
    }
 }
 
 Lines mapping:
-5 <-> 8
-7 <-> 12
-9 <-> 14
+5 <-> 7
+7 <-> 11
+9 <-> 13

--- a/testData/results/pkg/TestSwitchPatternMatching6.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching6.dec
@@ -4,10 +4,10 @@ import ext.Direction;
 
 public class TestSwitchPatternMatching6 {
    static int testTriangle(Direction d) {
-      return switch(d != null ? SyntheticClass_1.$SwitchMap$ext$Direction[d.ordinal()] : -1) {// 1 7
-         default -> -1;// 10
-         case 1, 2, 3 -> 0;// 8
-         case 4, 5 -> 1;// 9
+      return switch(d) {// 7
+         case null, default -> -1;// 10
+         case NORTH, SOUTH, WEST -> 0;// 8
+         case EAST, UP -> 1;// 9
       };
    }
 }
@@ -15,15 +15,6 @@ public class TestSwitchPatternMatching6 {
 class 'pkg/TestSwitchPatternMatching6' {
    method 'testTriangle (Lext/Direction;)I' {
       0      6
-      3      6
-      6      6
-      7      6
-      8      6
-      a      6
-      b      6
-      c      6
-      d      6
-      11      6
       12      6
       40      8
       44      9
@@ -33,8 +24,9 @@ class 'pkg/TestSwitchPatternMatching6' {
 }
 
 Lines mapping:
-1 <-> 7
 7 <-> 7
 8 <-> 9
 9 <-> 10
 10 <-> 8
+Not mapped:
+1

--- a/testData/results/pkg/TestSwitchPatternMatching7.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching7.dec
@@ -6,7 +6,7 @@ public class TestSwitchPatternMatching7 {
    static String test(Object s) {
       byte var2 = 0;
       switch(SwitchBootstraps.typeSwitch<"typeSwitch">(s, var2)) {
-         case int:
+         case null:
          default:
             return "everything";// 5 6
       }

--- a/testData/results/pkg/TestSwitchPatternMatching7.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching7.dec
@@ -2,7 +2,6 @@ package pkg;
 
 public class TestSwitchPatternMatching7 {
    static String test(Object s) {
-      byte var2 = 0;
       switch(s) {
          case null:
          default:
@@ -13,16 +12,14 @@ public class TestSwitchPatternMatching7 {
 
 class 'pkg/TestSwitchPatternMatching7' {
    method 'test (Ljava/lang/Object;)Ljava/lang/String;' {
-      0      5
-      2      4
-      3      4
-      b      5
-      1c      8
-      1d      8
-      1e      8
+      0      4
+      b      4
+      1c      7
+      1d      7
+      1e      7
    }
 }
 
 Lines mapping:
-5 <-> 9
-6 <-> 9
+5 <-> 8
+6 <-> 8

--- a/testData/results/pkg/TestSwitchPatternMatching7.dec
+++ b/testData/results/pkg/TestSwitchPatternMatching7.dec
@@ -1,11 +1,9 @@
 package pkg;
 
-import java.lang.runtime.SwitchBootstraps;
-
 public class TestSwitchPatternMatching7 {
    static String test(Object s) {
       byte var2 = 0;
-      switch(SwitchBootstraps.typeSwitch<"typeSwitch">(s, var2)) {
+      switch(s) {
          case null:
          default:
             return "everything";// 5 6
@@ -15,22 +13,16 @@ public class TestSwitchPatternMatching7 {
 
 class 'pkg/TestSwitchPatternMatching7' {
    method 'test (Ljava/lang/Object;)Ljava/lang/String;' {
-      0      7
-      2      6
-      3      6
-      5      7
-      6      7
-      7      7
-      8      7
-      9      7
-      a      7
-      b      7
-      1c      10
-      1d      10
-      1e      10
+      0      5
+      2      4
+      3      4
+      b      5
+      1c      8
+      1d      8
+      1e      8
    }
 }
 
 Lines mapping:
-5 <-> 11
-6 <-> 11
+5 <-> 9
+6 <-> 9

--- a/testData/results/pkg/TestSwitchPatternMatchingConstructor2.dec
+++ b/testData/results/pkg/TestSwitchPatternMatchingConstructor2.dec
@@ -1,6 +1,5 @@
 package pkg;
 
-import java.lang.runtime.SwitchBootstraps;
 import java.util.Objects;
 
 public class TestSwitchPatternMatchingConstructor2 {
@@ -22,7 +21,7 @@ public class TestSwitchPatternMatchingConstructor2 {
    private TestSwitchPatternMatchingConstructor2(Object s, boolean unused) {
       Objects.requireNonNull(s);
       byte var4 = 0;
-      switch(SwitchBootstraps.typeSwitch<"typeSwitch">(s, var4)) {
+      switch(s) {
          default:
             this("Non-triangle");// 16 17
       }
@@ -31,64 +30,57 @@ public class TestSwitchPatternMatchingConstructor2 {
 
 class 'pkg/TestSwitchPatternMatchingConstructor2' {
    method '<init> (Ljava/lang/String;)V' {
-      4      7
-      5      7
-      6      7
-      7      7
-      8      7
-      9      7
-      a      7
-      b      8
+      4      6
+      5      6
+      6      6
+      7      6
+      8      6
+      9      6
+      a      6
+      b      7
    }
 
    method '<init> (Ljava/lang/Object;)V' {
-      1      14
-      3      11
-      4      11
-      c      14
-      20      15
-      21      15
-      25      16
-      27      18
-      28      18
-      29      18
-      2a      19
+      1      13
+      3      10
+      4      10
+      c      13
+      20      14
+      21      14
+      25      15
+      27      17
+      28      17
+      29      17
+      2a      18
    }
 
    method '<init> (Ljava/lang/Object;Z)V' {
-      1      22
-      3      22
-      4      22
-      5      22
-      8      23
-      9      23
-      a      23
-      c      24
-      d      24
-      e      24
-      f      24
-      10      24
-      11      24
-      12      24
-      13      24
-      1c      26
-      1d      26
-      1e      26
-      1f      26
-      20      26
-      21      28
+      1      21
+      3      21
+      4      21
+      5      21
+      8      22
+      9      22
+      a      22
+      13      23
+      1c      25
+      1d      25
+      1e      25
+      1f      25
+      20      25
+      21      27
    }
 }
 
 Lines mapping:
-5 <-> 8
-6 <-> 9
-9 <-> 19
-10 <-> 16
-11 <-> 17
-13 <-> 20
-16 <-> 27
-17 <-> 27
-19 <-> 29
+5 <-> 7
+6 <-> 8
+9 <-> 18
+10 <-> 15
+11 <-> 16
+13 <-> 19
+16 <-> 26
+17 <-> 26
+19 <-> 28
 Not mapped:
 4

--- a/testData/results/pkg/TestSwitchPatternMatchingConstructor2.dec
+++ b/testData/results/pkg/TestSwitchPatternMatchingConstructor2.dec
@@ -8,7 +8,6 @@ public class TestSwitchPatternMatchingConstructor2 {
    }// 6
 
    private TestSwitchPatternMatchingConstructor2(Object s) {
-      byte var3 = 0;
       String var10001;
 
       switch(s) {
@@ -20,7 +19,6 @@ public class TestSwitchPatternMatchingConstructor2 {
 
    private TestSwitchPatternMatchingConstructor2(Object s, boolean unused) {
       Objects.requireNonNull(s);
-      byte var4 = 0;
       switch(s) {
          default:
             this("Non-triangle");// 16 17
@@ -41,46 +39,41 @@ class 'pkg/TestSwitchPatternMatchingConstructor2' {
    }
 
    method '<init> (Ljava/lang/Object;)V' {
-      1      13
-      3      10
-      4      10
-      c      13
-      20      14
-      21      14
-      25      15
-      27      17
-      28      17
-      29      17
-      2a      18
+      1      12
+      c      12
+      20      13
+      21      13
+      25      14
+      27      16
+      28      16
+      29      16
+      2a      17
    }
 
    method '<init> (Ljava/lang/Object;Z)V' {
-      1      21
-      3      21
-      4      21
-      5      21
-      8      22
-      9      22
-      a      22
-      13      23
-      1c      25
-      1d      25
-      1e      25
-      1f      25
-      20      25
-      21      27
+      1      20
+      3      20
+      4      20
+      5      20
+      13      21
+      1c      23
+      1d      23
+      1e      23
+      1f      23
+      20      23
+      21      25
    }
 }
 
 Lines mapping:
 5 <-> 7
 6 <-> 8
-9 <-> 18
-10 <-> 15
-11 <-> 16
-13 <-> 19
-16 <-> 26
-17 <-> 26
-19 <-> 28
+9 <-> 17
+10 <-> 14
+11 <-> 15
+13 <-> 18
+16 <-> 24
+17 <-> 24
+19 <-> 26
 Not mapped:
 4

--- a/testData/results/pkg/TestSwitchPatternMatchingReturn1.dec
+++ b/testData/results/pkg/TestSwitchPatternMatchingReturn1.dec
@@ -5,7 +5,6 @@ import java.util.Objects;
 public class TestSwitchPatternMatchingReturn1 {
    public int test(Object o) {
       Objects.requireNonNull(o);
-      byte var3 = 0;
       int var10000;
 
       switch(o) {
@@ -23,30 +22,28 @@ class 'pkg/TestSwitchPatternMatchingReturn1' {
       2      6
       3      6
       4      6
-      7      7
-      8      7
-      10      10
-      30      11
-      31      11
-      32      11
-      33      11
-      34      11
-      35      11
-      36      11
-      3e      12
-      3f      12
-      40      12
-      41      12
-      42      12
-      43      12
-      44      12
-      48      13
-      49      15
+      10      9
+      30      10
+      31      10
+      32      10
+      33      10
+      34      10
+      35      10
+      36      10
+      3e      11
+      3f      11
+      40      11
+      41      11
+      42      11
+      43      11
+      44      11
+      48      12
+      49      14
    }
 }
 
 Lines mapping:
-5 <-> 16
-6 <-> 12
-7 <-> 13
-8 <-> 14
+5 <-> 15
+6 <-> 11
+7 <-> 12
+8 <-> 13

--- a/testData/src/java17preview/pkg/TestSwitchPatternMatching10.java
+++ b/testData/src/java17preview/pkg/TestSwitchPatternMatching10.java
@@ -1,0 +1,11 @@
+package pkg;
+
+public class TestSwitchPatternMatching10 {
+  static void test(String s) {
+    switch (s) {
+      case "hi" -> System.out.println("hi");
+      case "bye" -> System.out.println("bye");
+      case null, default -> System.out.println("oh");
+    }
+  }
+}

--- a/testData/src/java17preview/pkg/TestSwitchPatternMatching11.java
+++ b/testData/src/java17preview/pkg/TestSwitchPatternMatching11.java
@@ -1,0 +1,12 @@
+package pkg;
+
+public class TestSwitchPatternMatching11 {
+  static String test(String s) {
+    return switch (s) {
+      case "hi" -> "hi";
+      case "bye" -> "bye";
+      case null -> null;
+      case default -> "oh";
+    };
+  }
+}

--- a/testData/src/java17preview/pkg/TestSwitchPatternMatching12.java
+++ b/testData/src/java17preview/pkg/TestSwitchPatternMatching12.java
@@ -1,0 +1,13 @@
+package pkg;
+
+import ext.Direction;
+
+public class TestSwitchPatternMatching12 {
+  static int testTriangle(boolean a, Direction l, Direction r) {
+    return switch (a ? l : r) {
+      case NORTH, SOUTH, WEST -> 0;
+      case EAST, UP -> 1;
+      case DOWN, null, default -> -1;
+    };
+  }
+}


### PR DESCRIPTION
Fixes
- Switch statements with `null` labels being decompiled as type labels
- Switch expressions with `null` values being decompiled as the name of the expression type
- Nullable enum switch resugaring
- Type switches with only one code block not being resugared
- Type switches leaving behind an unused synthetic variable