### PR TITLE
Don't run processing steps on statements the method doesn't have

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
+++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
@@ -219,37 +219,34 @@ public class MethodProcessorRunnable implements Runnable {
       LabelHelper.cleanUpEdges(root);
       decompileRecord.add("CleanupEdges", root);
 
-      // Merge loop
-      while (true) {
-        if (!root.hasLoops()) {
-          break;
-        }
-
-        decompileRecord.incrementMergeLoop();
-        decompileRecord.add("MergeLoopStart", root);
-
-        if (EliminateLoopsHelper.eliminateLoops(root, cl)) {
-          decompileRecord.add("EliminateLoops", root);
-          continue;
-        }
-
-        MergeHelper.enhanceLoops(root);
-        decompileRecord.add("EnhanceLoops", root);
-
-        if (LoopExtractHelper.extractLoops(root)) {
-          decompileRecord.add("ExtractLoops", root);
-          continue;
-        }
-
-        if (IfHelper.mergeAllIfs(root)) {
-          decompileRecord.add("MergeAllIfs", root);
-          // Continues with merge loop
-        } else {
-          break;
-        }
-      }
-
       if (root.hasLoops()) {
+        // Merge loop
+        while (true) {
+
+          decompileRecord.incrementMergeLoop();
+          decompileRecord.add("MergeLoopStart", root);
+
+          if (EliminateLoopsHelper.eliminateLoops(root, cl)) {
+            decompileRecord.add("EliminateLoops", root);
+            continue;
+          }
+
+          MergeHelper.enhanceLoops(root);
+          decompileRecord.add("EnhanceLoops", root);
+
+          if (LoopExtractHelper.extractLoops(root)) {
+            decompileRecord.add("ExtractLoops", root);
+            continue;
+          }
+
+          if (IfHelper.mergeAllIfs(root)) {
+            decompileRecord.add("MergeAllIfs", root);
+            // Continues with merge loop
+          } else {
+            break;
+          }
+        }
+
         decompileRecord.resetMergeLoop();
         decompileRecord.add("MergeLoopEnd", root);
       }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/RootStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/RootStatement.java
@@ -15,6 +15,7 @@ public final class RootStatement extends Statement {
   public final StructMethod mt;
   public Set<String> commentLines = null;
   public boolean addErrorComment = false;
+  private final ContentFlags flags = new ContentFlags();
 
   public RootStatement(Statement head, DummyExitStatement dummyExit, StructMethod mt) {
     super(StatementType.ROOT);
@@ -68,8 +69,44 @@ public final class RootStatement extends Statement {
     addErrorComment |= graph.addErrorComment;
   }
 
+  public void buildContentFlags() {
+    buildContentFlagsStat(this);
+  }
+
+  private void buildContentFlagsStat(Statement stat) {
+    for (Statement st : stat.stats) {
+      buildContentFlagsStat(st);
+    }
+
+    if (stat instanceof CatchStatement || stat instanceof CatchAllStatement) {
+      this.flags.hasTryCatch = true;
+    } else if (stat instanceof DoStatement) {
+      this.flags.hasLoops = true;
+    } else if (stat instanceof SwitchStatement) {
+      this.flags.hasSwitch = true;
+    }
+  }
+
+  public boolean hasTryCatch() {
+    return this.flags.hasTryCatch;
+  }
+
+  public boolean hasLoops() {
+    return this.flags.hasLoops;
+  }
+
+  public boolean hasSwitch() {
+    return this.flags.hasSwitch;
+  }
+
   @Override
   public StartEndPair getStartEndRange() {
     return StartEndPair.join(first.getStartEndRange(), dummyExit != null ? dummyExit.getStartEndRange() : null);
+  }
+
+  private static class ContentFlags {
+    private boolean hasTryCatch;
+    private boolean hasLoops;
+    private boolean hasSwitch;
   }
 }


### PR DESCRIPTION
Probably doesn't impact performance greatly, but may reduce iteration allocations for `new ArrayList<>(st.getStats())`.