### PR TITLE
Prevent merging of clashing types, when they are not correctly assignable to the other

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
@@ -789,6 +789,7 @@ public class VarDefinitionHelper {
   private VarType getMergedType(VarVersionPair from, VarVersionPair to) {
     Map<VarVersionPair, VarType> minTypes = varproc.getVarVersions().getTypeProcessor().getMapExprentMinTypes();
     Map<VarVersionPair, VarType> maxTypes = varproc.getVarVersions().getTypeProcessor().getMapExprentMaxTypes();
+
     return getMergedType(minTypes.get(from), minTypes.get(to), maxTypes.get(from), maxTypes.get(to));
   }
 
@@ -824,6 +825,13 @@ public class VarDefinitionHelper {
       }
       return null;
     } else {
+
+      // Both nonnull at this point
+      if (!fromMin.isStrictSuperset(toMin)) {
+        // If type we're merging into the old type isn't a strict superset of the old type, we cannot merge
+        return null;
+      }
+
       return type;
     }
   }

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -258,7 +258,6 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_8, "TestInlineAssignments");
     // TODO: Cast of (Func) is removed
     register(JAVA_8, "TestInterfaceLambdaCast");
-    // TODO: Local scope is removed, replaced with boolean cast
     register(JAVA_8, "TestLocalScopeClash");
     register(JAVA_8, "TestMultiBoolean");
     register(JAVA_8, "TestNestedFor");
@@ -284,6 +283,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_8, "TestWhileIterator");
     register(JAVA_8, "TestReturnTernaryChar");
     register(JAVA_8, "TestCompoundAssignment");
+    // TODO: testSuccessor2 makes a = 3 into a boolean
     register(JAVA_8, "TestInfiniteLoop");
     register(JAVA_8, "TestIfLoop");
     // Be careful when touching this class file, your IDE might freeze
@@ -536,9 +536,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_8, "TestInstanceStaticInvoke");
     // TODO: finally fails to be verified
     register(JAVA_8, "TestFinallyBlockVariableUse");
-    // TODO: improper boolean merge
     register(JAVA_8, "TestIntBoolMerge");
-    // TODO: improper boolean merge
     register(JAVA_8_NODEBUG, "TestIntBoolMergeNoDebug");
     register(JAVA_8, "TestInnerClassGeneric");
     // TODO: array access not simplified

--- a/testData/results/pkg/TestIntBoolMerge.dec
+++ b/testData/results/pkg/TestIntBoolMerge.dec
@@ -4,8 +4,8 @@ public class TestIntBoolMerge {
    public void test() {
       int i = 0;// 6
       System.out.println(i);// 7
-      i = 1;// 10
-      System.out.println((boolean)i);// 11
+      boolean ix = true;// 10
+      System.out.println(ix);// 11
    }// 13
 }
 

--- a/testData/results/pkg/TestIntBoolMergeNoDebug.dec
+++ b/testData/results/pkg/TestIntBoolMergeNoDebug.dec
@@ -4,8 +4,8 @@ public class TestIntBoolMergeNoDebug {
    public void test() {
       byte var1 = 0;
       System.out.println(var1);
-      var1 = 1;
-      System.out.println((boolean)var1);
+      boolean var2 = true;
+      System.out.println(var2);
    }
 }
 

--- a/testData/results/pkg/TestLocalScopeClash.dec
+++ b/testData/results/pkg/TestLocalScopeClash.dec
@@ -15,9 +15,9 @@ public class TestLocalScopeClash {
       i *= 2;// 20
       i += 2;// 21
       this.acceptInt(i);// 22
-      i = a & a & b;// 25 26
-      i ^= i || b;// 27
-      this.acceptBoolean((boolean)i);// 28
+      boolean var10 = a & a & b;// 25 26
+      var10 ^= var10 || b;// 27
+      this.acceptBoolean(var10);// 28
    }// 30
 }
 


### PR DESCRIPTION
This primarily prevents the merging of int and boolean types, which tended to get merged together even when it is not possible to assign them. This also creates a regression in `TestInfiniteLoop` where a nonone constant becomes boolean `true`, when it shouldn't be. This is likely due to the variable not having any uses. That bug will be addressed in an upcoming PR.