### PR TITLE
Add FlattenStatementsHelper support for switch cases

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
+++ b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
@@ -9,6 +9,7 @@ import org.jetbrains.java.decompiler.main.collectors.VarNamesCollector;
 import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
 import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
 import org.jetbrains.java.decompiler.modules.decompiler.exps.Exprent;
+import org.jetbrains.java.decompiler.modules.decompiler.flow.FlattenStatementsHelper;
 import org.jetbrains.java.decompiler.modules.decompiler.stats.RootStatement;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.VarProcessor;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionPair;
@@ -142,6 +143,13 @@ public class ClassWrapper {
         RootStatement rootStat = MethodProcessorRunnable.debugCurrentlyDecompiling.get();
         if (rootStat != null) {
           DotExporter.errorToDotFile(rootStat, mt, "fail");
+
+          try {
+            FlattenStatementsHelper flatten = new FlattenStatementsHelper();
+            DotExporter.errorToDotFile(flatten.buildDirectGraph(rootStat), mt, "failDigraph");
+          } catch (Exception e) {
+            // ignore
+          }
         }
 
         ControlFlowGraph graph = MethodProcessorRunnable.debugCurrentCFG.get();

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/flow/DirectEdge.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/flow/DirectEdge.java
@@ -51,4 +51,9 @@ public final class DirectEdge {
   public int hashCode() {
     return Objects.hash(source, destination, type);
   }
+
+  @Override
+  public String toString() {
+    return "(" + this.source + " -> " + this.destination + " | " + this.type + ")";
+  }
 }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/flow/DirectNodeType.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/flow/DirectNodeType.java
@@ -12,7 +12,8 @@ public enum DirectNodeType {
   CONDITION("cond"),
   INCREMENT("inc"),
   TRY("try"),
-  FOREACH_VARDEF("foreach");
+  FOREACH_VARDEF("foreach"),
+  CASE("case");
 
   private final String name;
 

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
@@ -485,6 +485,26 @@ public class Statement implements IMatchable {
     return false;
   }
 
+  public boolean containsStatementById(int statId) {
+    return this.id == statId || containsStatementStrictById(statId);
+  }
+
+  public boolean containsStatementStrictById(int statId) {
+    for (Statement stat : stats) {
+      if (stat.id == statId) {
+        return true;
+      }
+    }
+
+    for (Statement st : stats) {
+      if (st.containsStatementStrictById(statId)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   public TextBuffer toJava() {
     return toJava(0);
   }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
@@ -194,6 +194,17 @@ public final class SwitchStatement extends Statement {
     return buf;
   }
 
+  // Needed for flatten statements
+  public Statement findCaseBranchContaining(int id) {
+    for (Statement st : this.caseStatements) {
+      if (st.containsStatementById(id)) {
+        return st;
+      }
+    }
+
+    return null;
+  }
+
   @Override
   public void initExprents() {
     SwitchHeadExprent swexpr = (SwitchHeadExprent)first.getExprents().remove(first.getExprents().size() - 1);


### PR DESCRIPTION
This PR adds support for representing switch cases in FlattenStatementsHelper by intercepting edges leaving the switch head and adding a case node inbetween. Every test with a switch passes direct graph validation with these changes, meaning that no nodes have been isolated.