### PR TITLE
Don't process direct nodes when we've seen them already from another node in ExprProcessor

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
@@ -134,6 +134,8 @@ public class ExprProcessor implements CodeConstants {
     map.put(null, new PrimitiveExprsList());
     mapData.put(dgraph.first, map);
 
+    Set<DirectNode> seen = new HashSet<>();
+
     while (!stack.isEmpty()) {
 
       DirectNode node = stack.removeFirst();
@@ -168,7 +170,7 @@ public class ExprProcessor implements CodeConstants {
           }
         }
 
-        if (isSuccessor) {
+        if (!seen.contains(nd) && isSuccessor) {
           Map<String, PrimitiveExprsList> mapSucc = mapData.computeIfAbsent(nd, k -> new HashMap<>());
           LinkedList<String> ndentrypoints = new LinkedList<>(entrypoints);
 
@@ -189,6 +191,7 @@ public class ExprProcessor implements CodeConstants {
             }
           }
 
+          seen.add(nd);
           String ndentrykey = buildEntryPointKey(ndentrypoints);
           if (!mapSucc.containsKey(ndentrykey)) {
 


### PR DESCRIPTION
This fixes an OOM that we have been seeing, where calling this from within FinallyProcessor could lead to many new objects being created, overloading the garbage collector. I'm not 100% confident that this is the right fix, so I'll test a bit more on my own.