### PR TITLE
Added Implementation-Version to manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,8 @@ jar {
     attributes (
       'Multi-Release': 'true',
       'Main-Class': 'org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler',
-      'Implementation-Name': "Quiltflower"
+      'Implementation-Name': "Quiltflower",
+      'Implementation-Version': project.version
     )
   }
 }


### PR DESCRIPTION
1) To make the version number available from inside running application. (useful for an about dialog in a GUI displaying the version number)

2) If the jar was renamed for whatever reason, the version can still be found in the manifest,

