### PR TITLE
Test duplicate assignment in switch expression

### DIFF
--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -541,6 +541,8 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_8, "TestLocalVariableMergeSwitch");
     register(JAVA_8, "TestLoopBreak4");
     register(JAVA_17, "TestDoubleBraceInitializersJ17");
+    // TODO: code doesn't compile (redeclares variable)
+    register(JAVA_17, "TestDuplicateAssignmentInSwitchExpr");
     register(JAVA_8, "TestLoopMerging2");
     register(JAVA_8, "TestAssertConst");
     register(JAVA_8, "TestLambdaLocalCapture");

--- a/testData/results/pkg/TestDuplicateAssignmentInSwitchExpr.dec
+++ b/testData/results/pkg/TestDuplicateAssignmentInSwitchExpr.dec
@@ -1,0 +1,40 @@
+package pkg;
+
+public class TestDuplicateAssignmentInSwitchExpr {
+   void foo(int bar) {
+      int num = switch(bar) {// 5
+         case 0 -> {
+            int num;
+            yield num = 1;// 6
+         }
+         default -> 0;// 7
+      };
+      System.out.println(num);// 9
+   }// 10
+}
+
+class 'pkg/TestDuplicateAssignmentInSwitchExpr' {
+   method 'foo (I)V' {
+      0      4
+      1      4
+      14      7
+      16      7
+      1a      9
+      1b      4
+      1c      11
+      1d      11
+      1e      11
+      1f      11
+      20      11
+      21      11
+      22      11
+      23      12
+   }
+}
+
+Lines mapping:
+5 <-> 5
+6 <-> 8
+7 <-> 10
+9 <-> 12
+10 <-> 13

--- a/testData/src/java17/pkg/TestDuplicateAssignmentInSwitchExpr.java
+++ b/testData/src/java17/pkg/TestDuplicateAssignmentInSwitchExpr.java
@@ -1,0 +1,11 @@
+package pkg;
+
+public class TestDuplicateAssignmentInSwitchExpr {
+  void foo(int bar) {
+    int num = switch (bar) {
+      case 0 -> num = 1;
+      default -> 0;
+    };
+    System.out.println(num);
+  }
+}


### PR DESCRIPTION
The output fails to compile due to a redeclaration of a variable