### PR TITLE
fix: rename entities obfuscated class detection

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 public class ConverterHelper implements IIdentifierRenamer {
   private static final Set<String> KEYWORDS = new HashSet<>(Arrays.asList(
@@ -23,18 +24,22 @@ public class ConverterHelper implements IIdentifierRenamer {
   private int classCounter = 0;
   private int fieldCounter = 0;
   private int methodCounter = 0;
+  private static final Pattern OBF_REGEX = Pattern.compile("^(?:.{1,3}(?:$|\\$))+");
   private final Set<String> setNonStandardClassNames = new HashSet<>();
 
   @Override
   public boolean toBeRenamed(Type elementType, String className, String element, String descriptor) {
     String value = elementType == Type.ELEMENT_CLASS ? className : element;
+    boolean isWindowsReserved;
     return value == null ||
-           value.length() <= 2 ||
-           !isValidIdentifier(elementType == Type.ELEMENT_METHOD, value) ||
-           KEYWORDS.contains(value) ||
-           elementType == Type.ELEMENT_CLASS && (
-             RESERVED_WINDOWS_NAMESPACE.contains(value.toLowerCase(Locale.ENGLISH)) ||
-             value.length() > 255 - ".class".length());
+        value.isEmpty() ||
+        !isValidIdentifier(elementType == Type.ELEMENT_METHOD, value) ||
+        KEYWORDS.contains(value) ||
+        (!(isWindowsReserved = RESERVED_WINDOWS_NAMESPACE.contains(value.toLowerCase(Locale.ENGLISH))) &&
+            OBF_REGEX.matcher(value).matches()) ||
+        (elementType == Type.ELEMENT_CLASS && (
+            isWindowsReserved ||
+            value.length() > 255 - 6)); // account for .class
   }
 
   /**


### PR DESCRIPTION
Previously, it would not detect classes like `a$a` or `aaa$aaa` which caused some issues.
I am not sure if a cache would be needed since I am using regex now.
As an additional thought, the regex could be a cli paramater since names could be obfuscated differently.