### PR TITLE
fix: rename entities invalid cache key

### DIFF
--- a/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
+++ b/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
@@ -90,8 +90,15 @@ public final class MethodDescriptor {
         }
         else if (init) {
           // && isEnum
-          if (DecompilerContext.getOption(IFernflowerPreferences.DECOMPILE_ENUM) && DecompilerContext.getStructContext().getClass(struct.getClassQualifiedName()).hasModifier(CodeConstants.ACC_ENUM)) {
-            actualParams -= 2;
+          if (DecompilerContext.getOption(IFernflowerPreferences.DECOMPILE_ENUM)) {
+            String className = struct.getClassQualifiedName();
+            if (DecompilerContext.getOption(IFernflowerPreferences.RENAME_ENTITIES) && (className = DecompilerContext.getPoolInterceptor().getOldName(className)) == null) {
+              className = struct.getClassQualifiedName();
+            }
+
+            if (DecompilerContext.getStructContext().getClass(className).hasModifier(CodeConstants.ACC_ENUM)) {
+              actualParams -= 2;
+            }
           }
         }
         if (actualParams != sig.parameterTypes.size()) {


### PR DESCRIPTION
It seemed like an NPE came from StructMethods of renamed classes, the renamed class of which doesn't exist in the StructContext class cache.

Fixes point 4 of #112