### PR TITLE
Properly resolve source classes in wrong packages

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/Fernflower.java
+++ b/src/org/jetbrains/java/decompiler/main/Fernflower.java
@@ -184,9 +184,11 @@ public class Fernflower implements IDecompiledData {
       DecompilerContext.getLogger().writeMessage("Class " + cl.qualifiedName + " couldn't be fully decompiled.", t);
       if (DecompilerContext.getOption(IFernflowerPreferences.DUMP_EXCEPTION_ON_ERROR)) {
         List<String> lines = new ArrayList<>();
+        lines.add("/*");
         lines.add("$QF: Unable to decompile class");
         lines.addAll(ClassWriter.getErrorComment());
         ClassWriter.collectErrorLines(t, lines);
+        lines.add("*/");
         return String.join("\n", lines);
       } else {
         return null;

--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
@@ -235,7 +235,7 @@ public interface IFernflowerPreferences {
   String DUMP_BYTECODE_ON_ERROR = "dbe";
 
   @Name("Dump Exceptions On Error")
-  @Description("Put the exception message in the method body when an error occurs.")
+  @Description("Put the exception message in the method body or source file when an error occurs.")
   String DUMP_EXCEPTION_ON_ERROR = "dee";
 
   @Name("Decompiler Comments")

--- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
+++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
@@ -74,7 +74,12 @@ public class StructContext {
       if (unitForClass != null) {
         try {
           DecompilerContext.getLogger().writeMessage("Loading Class: " + key + " from " + unitForClass.getName(), IFernflowerLogger.Severity.INFO);
-          return StructClass.create(new DataInputFullStream(unitForClass.getClassBytes(key)), unitForClass.isOwn());
+          StructClass clazz = StructClass.create(new DataInputFullStream(unitForClass.getClassBytes(key)), unitForClass.isOwn());
+          if (!key.equals(clazz.qualifiedName)) {
+            // also place the class in the right key if it's wrong
+            this.classes.put(clazz.qualifiedName, clazz);
+          }
+          return clazz;
         } catch (final IOException ex) {
           DecompilerContext.getLogger().writeMessage("Failed to read class " + key + " from " + unitForClass.getName(), IFernflowerLogger.Severity.ERROR, ex);
         }


### PR DESCRIPTION
Fixes #201, by placing the loaded classes under the right key if it doesn't match their qualified name