### PR TITLE
Add a text tokens api

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The rest of options can be left as they are: they are aimed at professional reve
 - sfc (0): Debug comments showing the class SourceFile attribute if present
 - dcc (0): Decompile complex constant-dynamic bootstraps, that might have different or slower run-time behaviour when recompiled
 - dpr (1): Decompile preview features in latest Java versions
+- dtt (0): Dump text tokens on each decompiled file
 
 ### Renaming identifiers
 

--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -192,7 +192,8 @@ public class ClassWriter implements StatementWriter {
 
               VarVersionPair version = new VarVersionPair(index, 0);
               String parameterName = methodWrapper.varproc.getVarName(version);
-              buffer.appendVariable(parameterName == null ? "param" + index : parameterName, true, true, node.lambdaInformation.content_class_name, node.lambdaInformation.content_method_name, node.lambdaInformation.method_descriptor, index, parameterName); // null iff decompiled with errors
+              buffer.appendVariable(parameterName == null ? "param" + index : parameterName, // null iff decompiled with errors
+                true, true, node.lambdaInformation.content_class_name, node.lambdaInformation.content_method_name, md_content, index, parameterName);
 
               firstParameter = false;
             }

--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -162,7 +162,8 @@ public class ClassWriter implements StatementWriter {
         }
 
         buffer.append("::")
-          .appendMethod(CodeConstants.INIT_NAME.equals(node.lambdaInformation.content_method_name) ? "new" : node.lambdaInformation.content_method_name, false, node.lambdaInformation.content_class_name, node.lambdaInformation.content_method_name, node.lambdaInformation.content_method_descriptor);
+          .appendMethod(CodeConstants.INIT_NAME.equals(node.lambdaInformation.content_method_name) ? "new" : node.lambdaInformation.content_method_name,
+            false, node.lambdaInformation.content_class_name, node.lambdaInformation.content_method_name, node.lambdaInformation.content_method_descriptor);
       }
       else {
         // lambda method
@@ -190,8 +191,7 @@ public class ClassWriter implements StatementWriter {
                 buffer.append(", ");
               }
 
-              VarVersionPair version = new VarVersionPair(index, 0);
-              String parameterName = methodWrapper.varproc.getVarName(version);
+              String parameterName = methodWrapper.varproc.getVarName(new VarVersionPair(index, 0));
               buffer.appendVariable(parameterName == null ? "param" + index : parameterName, // null iff decompiled with errors
                 true, true, node.lambdaInformation.content_class_name, node.lambdaInformation.content_method_name, md_content, index, parameterName);
 

--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -205,8 +205,6 @@ public class ClassWriter implements StatementWriter {
           }
           buffer.append(" ->");
 
-          // @martrixx: left here!
-
           RootStatement root = wrapper.getMethodWrapper(mt.getName(), mt.getDescriptor()).root;
           if (DecompilerContext.getOption(IFernflowerPreferences.INLINE_SIMPLE_LAMBDAS) && methodWrapper.decompileError == null && root != null) {
             Statement firstStat = root.getFirst();
@@ -835,7 +833,7 @@ public class ClassWriter implements StatementWriter {
               typeName = ExprProcessor.getCastTypeName(VarType.VARTYPE_OBJECT);
             }
 
-            buffer.appendTypeName(typeName, type);
+            buffer.appendCastTypeName(typeName, type);
             buffer.append(" ");
 
             String parameterName = methodWrapper.varproc.getVarName(new VarVersionPair(index, 0));
@@ -1093,7 +1091,7 @@ public class ClassWriter implements StatementWriter {
                 DecompilerContext.getOption(IFernflowerPreferences.UNDEFINED_PARAM_TYPE_OBJECT)) {
               typeName = ExprProcessor.getCastTypeName(VarType.VARTYPE_OBJECT);
             }
-            buffer.appendTypeName(typeName, parameterType);
+            buffer.appendCastTypeName(typeName, parameterType);
             if (isVarArg) {
               buffer.append("...");
             }
@@ -1114,8 +1112,8 @@ public class ClassWriter implements StatementWriter {
 
             }
 
-            // TODO: var args could have wrong types???
-            buffer.appendVariable(parameterName == null ? "param" + index : parameterName, true, true, cl.qualifiedName, name, md, index, parameterName, parameterType); // null iff decompiled with errors
+            buffer.appendVariable(parameterName == null ? "param" + index : parameterName, // null iff decompiled with errors
+              true, true, cl.qualifiedName, mt.getName(), md, index, parameterName, parameterType);
 
             paramCount++;
           }

--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -192,7 +192,7 @@ public class ClassWriter implements StatementWriter {
 
               VarVersionPair version = new VarVersionPair(index, 0);
               String parameterName = methodWrapper.varproc.getVarName(version);
-              buffer.appendVariable(parameterName == null ? "param" + index : parameterName, true, true, node.lambdaInformation.content_class_name, node.lambdaInformation.content_method_name, node.lambdaInformation.method_descriptor, index, parameterName, methodWrapper.varproc.getVarType(version)); // null iff decompiled with errors
+              buffer.appendVariable(parameterName == null ? "param" + index : parameterName, true, true, node.lambdaInformation.content_class_name, node.lambdaInformation.content_method_name, node.lambdaInformation.method_descriptor, index, parameterName); // null iff decompiled with errors
 
               firstParameter = false;
             }
@@ -837,7 +837,8 @@ public class ClassWriter implements StatementWriter {
             buffer.append(" ");
 
             String parameterName = methodWrapper.varproc.getVarName(new VarVersionPair(index, 0));
-            buffer.appendVariable(parameterName == null ? "param" + index : parameterName, true, true, classWrapper.getClassStruct().qualifiedName, method_name, md_content, index, parameterName, type); // null iff decompiled with errors
+            buffer.appendVariable(parameterName == null ? "param" + index : parameterName, // null iff decompiled with errors
+              true, true, classWrapper.getClassStruct().qualifiedName, method_name, md_content, index, parameterName);
 
             firstParameter = false;
           }
@@ -1113,7 +1114,7 @@ public class ClassWriter implements StatementWriter {
             }
 
             buffer.appendVariable(parameterName == null ? "param" + index : parameterName, // null iff decompiled with errors
-              true, true, cl.qualifiedName, mt.getName(), md, index, parameterName, parameterType);
+              true, true, cl.qualifiedName, mt.getName(), md, index, parameterName);
 
             paramCount++;
           }

--- a/src/org/jetbrains/java/decompiler/main/Fernflower.java
+++ b/src/org/jetbrains/java/decompiler/main/Fernflower.java
@@ -9,11 +9,11 @@ import org.jetbrains.java.decompiler.modules.renamer.PoolInterceptor;
 import org.jetbrains.java.decompiler.struct.IDecompiledData;
 import org.jetbrains.java.decompiler.struct.StructClass;
 import org.jetbrains.java.decompiler.struct.StructContext;
-import org.jetbrains.java.decompiler.struct.lazy.LazyLoader;
 import org.jetbrains.java.decompiler.util.ClasspathScanner;
 import org.jetbrains.java.decompiler.util.JADNameProvider;
 import org.jetbrains.java.decompiler.util.JrtFinder;
 import org.jetbrains.java.decompiler.util.TextBuffer;
+import org.jetbrains.java.decompiler.util.token.TextTokenDumpVisitor;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -173,6 +173,9 @@ public class Fernflower implements IDecompiledData {
       TextBuffer buffer = new TextBuffer(ClassesProcessor.AVERAGE_CLASS_SIZE);
       buffer.append(DecompilerContext.getProperty(IFernflowerPreferences.BANNER).toString());
       classProcessor.writeClass(cl, buffer);
+      if (DecompilerContext.getOption(IFernflowerPreferences.DUMP_TEXT_TOKENS)) {
+        buffer.visitTokens(TextTokenVisitor.createVisitor(next -> new TextTokenDumpVisitor(next, buffer)));
+      }
       String res = buffer.convertToStringAndAllowDataDiscard();
       if (res == null) {
         return "$ FF: Unable to decompile class " + cl.qualifiedName;

--- a/src/org/jetbrains/java/decompiler/main/Fernflower.java
+++ b/src/org/jetbrains/java/decompiler/main/Fernflower.java
@@ -175,6 +175,8 @@ public class Fernflower implements IDecompiledData {
       classProcessor.writeClass(cl, buffer);
       if (DecompilerContext.getOption(IFernflowerPreferences.DUMP_TEXT_TOKENS)) {
         buffer.visitTokens(TextTokenVisitor.createVisitor(next -> new TextTokenDumpVisitor(next, buffer)));
+      } else {
+        buffer.visitTokens(TextTokenVisitor.createVisitor());
       }
       String res = buffer.convertToStringAndAllowDataDiscard();
       if (res == null) {

--- a/src/org/jetbrains/java/decompiler/main/Fernflower.java
+++ b/src/org/jetbrains/java/decompiler/main/Fernflower.java
@@ -173,11 +173,13 @@ public class Fernflower implements IDecompiledData {
       TextBuffer buffer = new TextBuffer(ClassesProcessor.AVERAGE_CLASS_SIZE);
       buffer.append(DecompilerContext.getProperty(IFernflowerPreferences.BANNER).toString());
       classProcessor.writeClass(cl, buffer);
+
       if (DecompilerContext.getOption(IFernflowerPreferences.DUMP_TEXT_TOKENS)) {
         buffer.visitTokens(TextTokenVisitor.createVisitor(next -> new TextTokenDumpVisitor(next, buffer)));
       } else {
         buffer.visitTokens(TextTokenVisitor.createVisitor());
       }
+
       String res = buffer.convertToStringAndAllowDataDiscard();
       if (res == null) {
         return "$ FF: Unable to decompile class " + cl.qualifiedName;

--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
@@ -258,6 +258,10 @@ public interface IFernflowerPreferences {
   @Description("Forces the processing of JSR instructions even if the class files shouldn't contain it (Java 7+)")
   String FORCE_JSR_INLINE = "fji";
 
+  @Name("Dump Text Tokens")
+  @Description("Dump Text Tokens on each class file")
+  String DUMP_TEXT_TOKENS = "dtt";
+
   Map<String, Object> DEFAULTS = getDefaults();
 
   static Map<String, Object> getDefaults() {
@@ -327,6 +331,7 @@ public interface IFernflowerPreferences {
     defaults.put(SOURCE_FILE_COMMENTS, "0");
     defaults.put(DECOMPILE_COMPLEX_CONDYS, "0");
     defaults.put(FORCE_JSR_INLINE, "0");
+    defaults.put(DUMP_TEXT_TOKENS, "0");
 
     return Collections.unmodifiableMap(defaults);
   }

--- a/src/org/jetbrains/java/decompiler/main/extern/TextTokenVisitor.java
+++ b/src/org/jetbrains/java/decompiler/main/extern/TextTokenVisitor.java
@@ -30,6 +30,7 @@ public abstract class TextTokenVisitor {
       property = new ArrayList<>();
       DecompilerContext.setProperty(PROPERTY_NAME, property);
     }
+
     return property;
   }
 
@@ -37,11 +38,19 @@ public abstract class TextTokenVisitor {
     getFactories().add(factory);
   }
 
-  public static TextTokenVisitor createVisitor(Factory factory) {
-    return getFactories().stream().reduce(Factory::andThen).orElse(v -> v).andThen(factory).create(EMPTY);
+  private static Factory chainFactories() {
+    return getFactories().stream().reduce(Factory::andThen).orElse(v -> v);
   }
 
-  public void start() {
+  public static TextTokenVisitor createVisitor() {
+    return chainFactories().create(EMPTY);
+  }
+
+  public static TextTokenVisitor createVisitor(Factory factory) {
+    return chainFactories().andThen(factory).create(EMPTY);
+  }
+
+  public void start(String content) {
   }
 
   public void visitClass(TextRange range, boolean declaration, String name) {

--- a/src/org/jetbrains/java/decompiler/main/extern/TextTokenVisitor.java
+++ b/src/org/jetbrains/java/decompiler/main/extern/TextTokenVisitor.java
@@ -8,7 +8,6 @@ import org.jetbrains.java.decompiler.util.token.TextRange;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 
 public abstract class TextTokenVisitor {
   private static final String PROPERTY_NAME = "text_token_visitor";
@@ -39,7 +38,7 @@ public abstract class TextTokenVisitor {
   }
 
   public static TextTokenVisitor createVisitor(Factory factory) {
-    return getFactories().stream().reduce((f1, f2) -> f1.andThen(f2)).orElse(v -> v).andThen(factory).apply(EMPTY);
+    return getFactories().stream().reduce(Factory::andThen).orElse(v -> v).andThen(factory).create(EMPTY);
   }
 
   public void start() {
@@ -78,9 +77,11 @@ public abstract class TextTokenVisitor {
   public void end() {
   }
 
-  public interface Factory extends Function<TextTokenVisitor, TextTokenVisitor> {
+  public interface Factory {
+    TextTokenVisitor create(TextTokenVisitor next);
+
     default Factory andThen(Factory after) {
-      return (Factory) Function.super.andThen(after);
+      return next -> after.create(create(next));
     }
   }
 }

--- a/src/org/jetbrains/java/decompiler/main/extern/TextTokenVisitor.java
+++ b/src/org/jetbrains/java/decompiler/main/extern/TextTokenVisitor.java
@@ -1,0 +1,86 @@
+package org.jetbrains.java.decompiler.main.extern;
+
+import org.jetbrains.java.decompiler.main.DecompilerContext;
+import org.jetbrains.java.decompiler.struct.gen.FieldDescriptor;
+import org.jetbrains.java.decompiler.struct.gen.MethodDescriptor;
+import org.jetbrains.java.decompiler.struct.gen.VarType;
+import org.jetbrains.java.decompiler.util.token.TextRange;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+public abstract class TextTokenVisitor {
+  private static final String PROPERTY_NAME = "text_token_visitor";
+  public static final TextTokenVisitor EMPTY = new TextTokenVisitor() {};
+
+  private final TextTokenVisitor next;
+
+  public TextTokenVisitor(TextTokenVisitor next) {
+    this.next = next;
+  }
+
+  private TextTokenVisitor() {
+    this.next = null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Factory> getFactories() {
+    List<Factory> property = (List<Factory>) DecompilerContext.getProperty(PROPERTY_NAME);
+    if (property == null) {
+      property = new ArrayList<>();
+      DecompilerContext.setProperty(PROPERTY_NAME, property);
+    }
+    return property;
+  }
+
+  public static void addVisitor(Factory factory) {
+    getFactories().add(factory);
+  }
+
+  public static TextTokenVisitor createVisitor(Factory factory) {
+    return getFactories().stream().reduce((f1, f2) -> f1.andThen(f2)).orElse(v -> v).andThen(factory).apply(EMPTY);
+  }
+
+  public void start() {
+  }
+
+  public void visitClass(TextRange range, boolean declaration, String name) {
+    if (next != null) {
+      next.visitClass(range, declaration, name);
+    }
+  }
+
+  public void visitField(TextRange range, boolean declaration, String className, String name, FieldDescriptor descriptor) {
+    if (next != null) {
+      next.visitField(range, declaration, className, name, descriptor);
+    }
+  }
+
+  public void visitMethod(TextRange range, boolean declaration, String className, String name, MethodDescriptor descriptor) {
+    if (next != null) {
+      next.visitMethod(range, declaration, className, name, descriptor);
+    }
+  }
+
+  public void visitParameter(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, VarType type) {
+    if (next != null) {
+      next.visitParameter(range, declaration, className, methodName, methodDescriptor, index, name, type);
+    }
+  }
+
+  public void visitLocal(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, VarType type) {
+    if (next != null) {
+      next.visitLocal(range, declaration, className, methodName, methodDescriptor, index, name, type);
+    }
+  }
+
+  public void end() {
+  }
+
+  public interface Factory extends Function<TextTokenVisitor, TextTokenVisitor> {
+    default Factory andThen(Factory after) {
+      return (Factory) Function.super.andThen(after);
+    }
+  }
+}

--- a/src/org/jetbrains/java/decompiler/main/extern/TextTokenVisitor.java
+++ b/src/org/jetbrains/java/decompiler/main/extern/TextTokenVisitor.java
@@ -71,15 +71,15 @@ public abstract class TextTokenVisitor {
     }
   }
 
-  public void visitParameter(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, VarType type) {
+  public void visitParameter(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name) {
     if (next != null) {
-      next.visitParameter(range, declaration, className, methodName, methodDescriptor, index, name, type);
+      next.visitParameter(range, declaration, className, methodName, methodDescriptor, index, name);
     }
   }
 
-  public void visitLocal(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, VarType type) {
+  public void visitLocal(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name) {
     if (next != null) {
-      next.visitLocal(range, declaration, className, methodName, methodDescriptor, index, name, type);
+      next.visitLocal(range, declaration, className, methodName, methodDescriptor, index, name);
     }
   }
 

--- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
+++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
@@ -265,6 +265,7 @@ public class NestedClassProcessor {
     }
     VarNamesCollector enclosingCollector = new VarNamesCollector(usedBefore);
 
+    Map<VarVersionPair, VarVersionPair> originalVersions = new HashMap<>();
     Map<VarVersionPair, String> mapNewNames = new HashMap<>();
     Map<VarVersionPair, LocalVariable> lvts = new HashMap<>();
 
@@ -301,9 +302,11 @@ public class NestedClassProcessor {
                 Exprent param = inv_dynamic.getLstParameters().get(param_index + i);
 
                 if (param instanceof VarExprent) {
-                  mapNewNames.put(varVersion, enclosingVarProc.getVarName(new VarVersionPair((VarExprent)param)));
+                  VarVersionPair paramVersion = new VarVersionPair((VarExprent) param);
+                  originalVersions.put(varVersion, paramVersion);
+                  mapNewNames.put(varVersion, enclosingVarProc.getVarName(paramVersion));
                   lvts.put(varVersion, ((VarExprent)param).getLVT());
-                  if (enclosingVarProc.getVarFinal((new VarVersionPair((VarExprent)param))) == FinalType.NON_FINAL) {
+                  if (enclosingVarProc.getVarFinal(paramVersion) == FinalType.NON_FINAL) {
                     //DecompilerContext.getLogger().writeMessage("Lambda in " + parent.simpleName + "." + enclosingMethod.methodStruct.getName() + " given non-final var " + ((VarExprent)param).getName() + "!", IFernflowerLogger.Severity.ERROR);
                   }
                 }
@@ -331,10 +334,14 @@ public class NestedClassProcessor {
     for (Entry<VarVersionPair, String> entry : mapNewNames.entrySet()) {
       VarVersionPair pair = entry.getKey();
       LocalVariable lvt = lvts.get(pair);
+      VarVersionPair original = originalVersions.get(pair);
 
       varProc.setVarName(pair, entry.getValue());
       if (lvt != null) {
         varProc.setVarLVT(pair, lvt);
+      }
+      if (original != null) {
+        varProc.setVarSource(pair, child.enclosingMethod, original);
       }
     }
 

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
@@ -1065,11 +1065,11 @@ public class ExprProcessor implements CodeConstants {
     }
 
     if (cast) {
-      buffer.append('(').append(getCastTypeName(leftType)).append(')');
+      buffer.append('(').appendCastTypeName(leftType).append(')');
     }
 
     if (castLambda) {
-      buffer.append('(').append(getCastTypeName(rightType)).append(')');
+      buffer.append('(').appendCastTypeName(rightType).append(')');
     }
 
     if (quote) {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AnnotationExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AnnotationExprent.java
@@ -44,14 +44,14 @@ public class AnnotationExprent extends Exprent {
 
     return new AnnotationExprent(className, parNames, exps);
   }
-  
+
   @Override
   public TextBuffer toJava(int indent) {
     TextBuffer buffer = new TextBuffer();
 
     buffer.appendIndent(indent);
     buffer.append('@');
-    buffer.append(DecompilerContext.getImportCollector().getShortName(ExprProcessor.buildJavaClassName(className)));
+    buffer.appendClass(DecompilerContext.getImportCollector().getShortName(ExprProcessor.buildJavaClassName(className)), false, className);
 
     Type type = getAnnotationType();
 

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AnnotationExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AnnotationExprent.java
@@ -51,7 +51,7 @@ public class AnnotationExprent extends Exprent {
 
     buffer.appendIndent(indent);
     buffer.append('@');
-    buffer.appendClass(DecompilerContext.getImportCollector().getShortName(ExprProcessor.buildJavaClassName(className)), false, className);
+    buffer.appendAllClasses(DecompilerContext.getImportCollector().getShortName(ExprProcessor.buildJavaClassName(className)), className);
 
     Type type = getAnnotationType();
 

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
@@ -83,7 +83,7 @@ public class ArrayExprent extends Exprent {
     if (arrType.arrayDim == 0) {
       VarType objArr = VarType.VARTYPE_OBJECT.resizeArrayDim(1); // type family does not change
       res.enclose("((" + ExprProcessor.getCastTypeName(objArr) + ")", ")");
-      res.addCastTypeNameToken(objArr, 2);
+      res.addTypeNameToken(objArr, 2);
     }
 
     res.addBytecodeMapping(bytecode);

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
@@ -83,6 +83,7 @@ public class ArrayExprent extends Exprent {
     if (arrType.arrayDim == 0) {
       VarType objArr = VarType.VARTYPE_OBJECT.resizeArrayDim(1); // type family does not change
       res.enclose("((" + ExprProcessor.getCastTypeName(objArr) + ")", ")");
+      res.addCastTypeNameToken(objArr, 2);
     }
 
     res.addBytecodeMapping(bytecode);

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
@@ -302,7 +302,7 @@ public class AssignmentExprent extends Exprent {
     }
 
     buf.prepend("(" + ExprProcessor.getCastTypeName(left) + ")");
-      buf.addTypeNameToken(left, 1);
+    buf.addTypeNameToken(left, 1);
   }
 
   @Override

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
@@ -302,7 +302,7 @@ public class AssignmentExprent extends Exprent {
     }
 
     buf.prepend("(" + ExprProcessor.getCastTypeName(left) + ")");
-    buf.addCastTypeNameToken(left, 1);
+      buf.addTypeNameToken(left, 1);
   }
 
   @Override

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
@@ -118,7 +118,8 @@ public class AssignmentExprent extends Exprent {
     TextBuffer buffer = new TextBuffer();
 
     if (fieldInClassInit) {
-      buffer.append(((FieldExprent) left).getName());
+      FieldExprent field = (FieldExprent) left;
+      buffer.appendField(field.getName(), false, field.getClassname(), field.getName(), field.getDescriptor());
     } else {
       buffer.append(left.toJava(indent));
     }
@@ -301,6 +302,7 @@ public class AssignmentExprent extends Exprent {
     }
 
     buf.prepend("(" + ExprProcessor.getCastTypeName(left) + ")");
+    buf.addCastTypeNameToken(left, 1);
   }
 
   @Override

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
@@ -228,7 +228,7 @@ public class ConstExprent extends Exprent {
     }
 
     if (constType.type != CodeConstants.TYPE_NULL && value == null) {
-      return buf.append(ExprProcessor.getCastTypeName(constType));
+      return buf.appendCastTypeName(constType);
     }
 
     VarType unboxed = VarType.UNBOXING_TYPES.getOrDefault(constType, constType);
@@ -352,7 +352,7 @@ public class ConstExprent extends Exprent {
         else if (constType.equals(VarType.VARTYPE_CLASS)) {
           String stringVal = value.toString();
           VarType type = new VarType(stringVal, !stringVal.startsWith("["));
-          return buf.append(ExprProcessor.getCastTypeName(type)).append(".class");
+          return buf.appendCastTypeName(type).append(".class");
         }
     }
 

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
@@ -258,7 +258,7 @@ public abstract class Exprent implements IMatchable {
     buf.append("<");
     //TODO: Check target output level and use <> operator?
     for (int i = 0; i < genericArgs.size(); i++) {
-      buf.append(ExprProcessor.getCastTypeName(genericArgs.get(i)));
+      buf.appendCastTypeName(genericArgs.get(i));
       if(i + 1 < genericArgs.size()) {
         buf.append(", ");
       }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
@@ -148,7 +148,7 @@ public class FieldExprent extends Exprent {
 
     if (isStatic) {
       if (useQualifiedStatic()) {
-        buf.appendClass(DecompilerContext.getImportCollector().getShortNameInClassContext(ExprProcessor.buildJavaClassName(classname)), false, classname);
+        buf.appendAllClasses(DecompilerContext.getImportCollector().getShortNameInClassContext(ExprProcessor.buildJavaClassName(classname)), classname);
         buf.append(".");
       }
     }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
@@ -148,7 +148,7 @@ public class FieldExprent extends Exprent {
 
     if (isStatic) {
       if (useQualifiedStatic()) {
-        buf.append(DecompilerContext.getImportCollector().getShortNameInClassContext(ExprProcessor.buildJavaClassName(classname)));
+        buf.appendClass(DecompilerContext.getImportCollector().getShortNameInClassContext(ExprProcessor.buildJavaClassName(classname)), false, classname);
         buf.append(".");
       }
     }
@@ -209,7 +209,7 @@ public class FieldExprent extends Exprent {
 
     buf.addBytecodeMapping(bytecode);
 
-    buf.append(name);
+    buf.appendField(name, false, classname, name, descriptor);
 
     return buf;
   }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
@@ -554,7 +554,7 @@ public class FunctionExprent extends Exprent {
         if (arr.getExprType().arrayDim == 0) {
           VarType objArr = VarType.VARTYPE_OBJECT.resizeArrayDim(1); // type family does not change
           buf.enclose("((" + ExprProcessor.getCastTypeName(objArr) + ")", ")");
-          buf.addCastTypeNameToken(objArr, 2);
+            buf.addTypeNameToken(objArr, 2);
         }
         return buf.append(".length");
       case TERNARY:

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
@@ -554,6 +554,7 @@ public class FunctionExprent extends Exprent {
         if (arr.getExprType().arrayDim == 0) {
           VarType objArr = VarType.VARTYPE_OBJECT.resizeArrayDim(1); // type family does not change
           buf.enclose("((" + ExprProcessor.getCastTypeName(objArr) + ")", ")");
+          buf.addCastTypeNameToken(objArr, 2);
         }
         return buf.append(".length");
       case TERNARY:
@@ -602,7 +603,8 @@ public class FunctionExprent extends Exprent {
         }
       }
       return buf.append(wrapOperandString(lstOperands.get(0), true, indent))
-                .prepend("(" + ExprProcessor.getTypeName(funcType.castType) + ")");
+                .prepend("(" + ExprProcessor.getTypeName(funcType.castType) + ")")
+                .addTypeNameToken(funcType.castType, 1);
     }
 
     //        return "<unknown function>";

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
@@ -554,7 +554,7 @@ public class FunctionExprent extends Exprent {
         if (arr.getExprType().arrayDim == 0) {
           VarType objArr = VarType.VARTYPE_OBJECT.resizeArrayDim(1); // type family does not change
           buf.enclose("((" + ExprProcessor.getCastTypeName(objArr) + ")", ")");
-            buf.addTypeNameToken(objArr, 2);
+          buf.addTypeNameToken(objArr, 2);
         }
         return buf.append(".length");
       case TERNARY:

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
@@ -602,12 +602,12 @@ public class InvocationExprent extends Exprent {
       }
 
       if (invocationType == InvocationType.CONSTANT_DYNAMIC) {
-        buf.append('(').append(ExprProcessor.getCastTypeName(descriptor.ret)).append(')');
+        buf.append('(').appendCastTypeName(descriptor.ret).append(')');
       }
 
       ClassNode node = (ClassNode)DecompilerContext.getProperty(DecompilerContext.CURRENT_CLASS_NODE);
       if (node == null || !classname.equals(node.classStruct.qualifiedName)) {
-        buf.append(DecompilerContext.getImportCollector().getShortNameInClassContext(ExprProcessor.buildJavaClassName(classname)));
+        buf.appendClass(DecompilerContext.getImportCollector().getShortNameInClassContext(ExprProcessor.buildJavaClassName(classname)), false, classname);
       }
     }
     else {
@@ -644,7 +644,7 @@ public class InvocationExprent extends Exprent {
 
       // Signature polymorphic methods returning Object require a cast to the return type in the descriptor
       if (CodeConstants.isReturnPolymorphic(classname, name) && !descriptor.ret.equals(VarType.VARTYPE_VOID)) {
-        buf.append('(').append(ExprProcessor.getCastTypeName(descriptor.ret)).append(')');
+        buf.append('(').appendCastTypeName(descriptor.ret).append(')');
       }
 
       if (functype == Type.GENERAL) {
@@ -704,7 +704,7 @@ public class InvocationExprent extends Exprent {
           // Don't cast to anonymous classes, since they by definition can't have a name
           // TODO: better fix may be to change equals to isSuperSet? all anonymous classes are superset of Object
           if (rightType.equals(VarType.VARTYPE_OBJECT) && !leftType.equals(rightType) && (instNode != null && instNode.type != ClassNode.Type.ANONYMOUS)) {
-            buf.append("((").append(ExprProcessor.getCastTypeName(leftType)).append(")");
+            buf.append("((").appendCastTypeName(leftType).append(")");
 
             if (instance.getPrecedence() >= FunctionType.CAST.precedence) {
               res.enclose("(", ")");
@@ -718,7 +718,7 @@ public class InvocationExprent extends Exprent {
           //This isn't properly handled by the compiler. So explicit casts are needed to retain J8 compatibility.
           else if (JAVA_NIO_BUFFER.equals(descriptor.ret) && !JAVA_NIO_BUFFER.equals(rightType)
               && DecompilerContext.getStructContext().instanceOf(rightType.value, JAVA_NIO_BUFFER.value)) {
-              buf.append("((").append(ExprProcessor.getCastTypeName(JAVA_NIO_BUFFER)).append(")").append(res).append(")");
+              buf.append("((").appendCastTypeName(JAVA_NIO_BUFFER).append(")").append(res).append(")");
           }
           else {
             buf.append(res);
@@ -746,7 +746,7 @@ public class InvocationExprent extends Exprent {
 
         if (invocationType == InvocationType.DYNAMIC || invocationType == InvocationType.CONSTANT_DYNAMIC) {
           if (bootstrapMethod == null) {
-            buf.append("<").append(name);
+            buf.append("<").appendMethod(name, false, classname, name, descriptor);
             if (invocationType == InvocationType.DYNAMIC) {
               buf.append(">invokedynamic");
             } else {
@@ -754,7 +754,7 @@ public class InvocationExprent extends Exprent {
             }
           } else {
             buf.append(bootstrapMethod.elementname);
-            buf.append("<\"").append(name).append('"');
+            buf.append("<\"").appendMethod(name, false, classname, name, descriptor).append('"');
             for (PooledConstant arg : bootstrapArguments) {
               buf.append(',');
               appendBootstrapArgument(buf, arg);
@@ -762,7 +762,7 @@ public class InvocationExprent extends Exprent {
             buf.append('>');
           }
         } else {
-          buf.append(name);
+          buf.appendMethod(name, false, classname, name, descriptor);
         }
 
         buf.append("(");
@@ -820,7 +820,7 @@ public class InvocationExprent extends Exprent {
       Object value = prim.value;
       String stringValue = String.valueOf(value);
       if (prim.type == CodeConstants.CONSTANT_Class) {
-        buf.append(ExprProcessor.getCastTypeName(new VarType(stringValue)));
+        buf.appendCastTypeName(new VarType(stringValue));
       } else if (prim.type == CodeConstants.CONSTANT_String) {
         buf.append('"').append(ConstExprent.convertStringToJava(stringValue, false)).append('"');
       } else {
@@ -829,7 +829,7 @@ public class InvocationExprent extends Exprent {
     } else if (arg instanceof LinkConstant) {
       // TODO: errors trying to print condy as const arg
       VarType cls = new VarType(((LinkConstant) arg).classname);
-      buf.append(ExprProcessor.getCastTypeName(cls)).append("::").append(((LinkConstant) arg).elementname);
+      buf.appendCastTypeName(cls).append("::").append(((LinkConstant) arg).elementname);
     }
   }
 

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
@@ -607,7 +607,7 @@ public class InvocationExprent extends Exprent {
 
       ClassNode node = (ClassNode)DecompilerContext.getProperty(DecompilerContext.CURRENT_CLASS_NODE);
       if (node == null || !classname.equals(node.classStruct.qualifiedName)) {
-        buf.appendClass(DecompilerContext.getImportCollector().getShortNameInClassContext(ExprProcessor.buildJavaClassName(classname)), false, classname);
+        buf.appendAllClasses(DecompilerContext.getImportCollector().getShortNameInClassContext(ExprProcessor.buildJavaClassName(classname)), classname);
       }
     }
     else {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
@@ -360,7 +360,7 @@ public class NewExprent extends Exprent {
           }
 
           if (appendType) {
-            buf.append(typename);
+            buf.appendCastTypeName(typename, child.anonymousClassType);
           }
         }
       }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
@@ -347,13 +347,13 @@ public class NewExprent extends Exprent {
             GenericClassDescriptor descriptor = child.getWrapper().getClassStruct().getSignature();
             if (descriptor != null) {
               if (descriptor.superinterfaces.isEmpty()) {
-                buf.append(ExprProcessor.getCastTypeName(descriptor.superclass));
+                buf.appendCastTypeName(descriptor.superclass);
               } else {
                 if (descriptor.superinterfaces.size() > 1 && !lambda) {
                   DecompilerContext.getLogger().writeMessage("Inconsistent anonymous class signature: " + child.classStruct.qualifiedName,
                     IFernflowerLogger.Severity.WARN);
                 }
-                buf.append(ExprProcessor.getCastTypeName(descriptor.superinterfaces.get(0)));
+                buf.appendCastTypeName(descriptor.superinterfaces.get(0));
               }
               appendType = false;
             }
@@ -436,7 +436,7 @@ public class NewExprent extends Exprent {
             typename = typename.substring(typename.lastIndexOf('.') + 1);
           }
         }
-        buf.append(typename);
+        buf.appendTypeName(typename, newType);
       }
 
       if (constructor != null) {
@@ -468,11 +468,12 @@ public class NewExprent extends Exprent {
         VarType elementType = lstArrayElements.get(0).getExprType();
         if (elementType.type == CodeConstants.TYPE_OBJECT && elementType.value.equals("java/lang/Object") && elementType.arrayDim >= 1) {
           buf.prepend("(Object)");
+          buf.addClassToken(1, 6, "java/lang/Object");
         }
       }
     }
     else {
-      buf.append("new ").append(ExprProcessor.getTypeName(newType));
+      buf.append("new ").appendTypeName(newType);
 
       if (lstArrayElements.isEmpty()) {
         for (int i = 0; i < newType.arrayDim; i++) {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
@@ -90,7 +90,8 @@ public class SwitchExprent extends Exprent {
         }
 
         if (value instanceof FieldExprent && ((FieldExprent) value).isStatic()) { // enum values
-          buf.append(((FieldExprent) value).getName());
+          FieldExprent field = (FieldExprent) value;
+          buf.appendField(field.getName(), false, field.getClassname(), field.getName(), field.getDescriptor());
         } else if (value instanceof FunctionExprent && ((FunctionExprent) value).getFuncType() == FunctionExprent.FunctionType.INSTANCEOF) {
           // Pattern matching variables
           List<Exprent> operands = ((FunctionExprent) value).getLstOperands();

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
@@ -123,10 +123,11 @@ public class VarExprent extends Exprent {
         if (processor != null && processor.getVarFinal(varVersion) == FinalType.EXPLICIT_FINAL) {
           buffer.append("final ");
         }
-        buffer.append(getDefinitionType());
+        buffer.appendCastTypeName(getDefinitionVarType());
         buffer.append(" ");
       }
 
+      // FIXME: tokenize - How can I check whether this var is a parameter?
       buffer.append(getName());
     }
 
@@ -154,6 +155,10 @@ public class VarExprent extends Exprent {
   */
 
   public String getDefinitionType() {
+    return ExprProcessor.getCastTypeName(getDefinitionVarType());
+  }
+
+  public VarType getDefinitionVarType() {
     if (DecompilerContext.getOption(IFernflowerPreferences.USE_DEBUG_VAR_NAMES)) {
 
       if (lvt != null) {
@@ -161,11 +166,11 @@ public class VarExprent extends Exprent {
           if (lvt.getSignature() != null) {
             GenericFieldDescriptor descriptor = GenericMain.parseFieldSignature(lvt.getSignature());
             if (descriptor != null) {
-              return ExprProcessor.getCastTypeName(descriptor.type);
+              return descriptor.type;
             }
           }
         }
-        return ExprProcessor.getCastTypeName(getVarType());
+        return getVarType();
       }
 
       MethodWrapper method = (MethodWrapper)DecompilerContext.getProperty(DecompilerContext.CURRENT_METHOD_WRAPPER);
@@ -185,7 +190,7 @@ public class VarExprent extends Exprent {
               if (signature != null) {
                 GenericFieldDescriptor descriptor = GenericMain.parseFieldSignature(signature);
                 if (descriptor != null) {
-                  return ExprProcessor.getCastTypeName(descriptor.type);
+                  return descriptor.type;
                 }
               }
             }
@@ -196,14 +201,14 @@ public class VarExprent extends Exprent {
           if (attr != null) {
             String descriptor = attr.getDescriptor(originalIndex, visibleOffset);
             if (descriptor != null) {
-              return ExprProcessor.getCastTypeName(new VarType(descriptor));
+              return new VarType(descriptor);
             }
           }
         }
       }
     }
 
-    return ExprProcessor.getCastTypeName(getVarType());
+    return getVarType();
   }
 
   @Override

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
@@ -141,7 +141,7 @@ public class VarExprent extends Exprent {
           param = i <= Arrays.stream(descriptor.params).map(v -> v.stackSize).reduce(0, Integer::sum);
         }
 
-        buffer.appendVariable(name, false, param, method.classStruct.qualifiedName, method.methodStruct.getName(), descriptor, index, name);
+        buffer.appendVariable(name, definition, param, method.classStruct.qualifiedName, method.methodStruct.getName(), descriptor, index, name);
       } else {
         buffer.append(name);
       }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarProcessor.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarProcessor.java
@@ -10,6 +10,7 @@ import org.jetbrains.java.decompiler.struct.StructMethod;
 import org.jetbrains.java.decompiler.struct.attr.StructLocalVariableTableAttribute.LocalVariable;
 import org.jetbrains.java.decompiler.struct.gen.MethodDescriptor;
 import org.jetbrains.java.decompiler.struct.gen.VarType;
+import org.jetbrains.java.decompiler.util.Pair;
 import org.jetbrains.java.decompiler.util.StartEndPair;
 import org.jetbrains.java.decompiler.util.TextUtil;
 
@@ -29,6 +30,8 @@ public class VarProcessor {
   private final Set<VarVersionPair> externalVars = new HashSet<>();
   private final Map<VarVersionPair, String> clashingNames = new HashMap<>();
   private final Set<Integer> syntheticSemaphores = new HashSet<>();
+  // var -> (method, var in method)
+  private final Map<VarVersionPair, Pair<String, VarVersionPair>> varSources = new HashMap<>();
   public boolean nestedProcessed;
 
   public VarProcessor(StructMethod mt, MethodDescriptor md) {
@@ -145,6 +148,10 @@ public class VarProcessor {
     mapVarNames.put(pair, name);
   }
 
+  public void setVarSource(VarVersionPair pair, String method, VarVersionPair original) {
+    varSources.put(pair, Pair.of(method, original));
+  }
+
   public Set<VarVersionPair> getUsedVarVersions() {
     return mapVarNames != null ? mapVarNames.keySet() : Collections.emptySet();
   }
@@ -155,6 +162,10 @@ public class VarProcessor {
 
   public FinalType getVarFinal(VarVersionPair pair) {
     return varVersions == null ? FinalType.FINAL : varVersions.getVarFinal(pair);
+  }
+
+  public Pair<String, VarVersionPair> getVarSource(VarVersionPair pair) {
+    return varSources.get(pair);
   }
 
   public void setVarFinal(VarVersionPair pair, FinalType finalType) {

--- a/src/org/jetbrains/java/decompiler/util/TextBuffer.java
+++ b/src/org/jetbrains/java/decompiler/util/TextBuffer.java
@@ -230,12 +230,12 @@ public class TextBuffer {
     return append(value);
   }
 
-  public TextBuffer appendVariable(String value, boolean declaration, boolean parameter, String className, String methodName, String methodDescriptor, int index, String name, VarType type) {
-    return appendVariable(value, declaration, parameter, className, methodName, MethodDescriptor.parseDescriptor(methodDescriptor), index, name, type);
+  public TextBuffer appendVariable(String value, boolean declaration, boolean parameter, String className, String methodName, String methodDescriptor, int index, String name) {
+    return appendVariable(value, declaration, parameter, className, methodName, MethodDescriptor.parseDescriptor(methodDescriptor), index, name);
   }
 
-  public TextBuffer appendVariable(String value, boolean declaration, boolean parameter, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, VarType type) {
-    addToken(new VariableTextToken(length(), value.length(), declaration, parameter, className, methodName, methodDescriptor, index, name, type));
+  public TextBuffer appendVariable(String value, boolean declaration, boolean parameter, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name) {
+    addToken(new VariableTextToken(length(), value.length(), declaration, parameter, className, methodName, methodDescriptor, index, name));
     return append(value);
   }
 

--- a/src/org/jetbrains/java/decompiler/util/TextUtil.java
+++ b/src/org/jetbrains/java/decompiler/util/TextUtil.java
@@ -22,7 +22,7 @@ public final class TextUtil {
   public static void writeQualifiedSuper(TextBuffer buf, String qualifier) {
     ClassesProcessor.ClassNode classNode = (ClassesProcessor.ClassNode)DecompilerContext.getProperty(DecompilerContext.CURRENT_CLASS_NODE);
     if (!qualifier.equals(classNode.classStruct.qualifiedName)) {
-      buf.appendClass(DecompilerContext.getImportCollector().getShortName(ExprProcessor.buildJavaClassName(qualifier)), false, qualifier).append('.');
+      buf.appendAllClasses(DecompilerContext.getImportCollector().getShortName(ExprProcessor.buildJavaClassName(qualifier)), qualifier).append('.');
     }
     buf.append("super");
   }

--- a/src/org/jetbrains/java/decompiler/util/TextUtil.java
+++ b/src/org/jetbrains/java/decompiler/util/TextUtil.java
@@ -22,7 +22,7 @@ public final class TextUtil {
   public static void writeQualifiedSuper(TextBuffer buf, String qualifier) {
     ClassesProcessor.ClassNode classNode = (ClassesProcessor.ClassNode)DecompilerContext.getProperty(DecompilerContext.CURRENT_CLASS_NODE);
     if (!qualifier.equals(classNode.classStruct.qualifiedName)) {
-      buf.append(DecompilerContext.getImportCollector().getShortName(ExprProcessor.buildJavaClassName(qualifier))).append('.');
+      buf.appendClass(DecompilerContext.getImportCollector().getShortName(ExprProcessor.buildJavaClassName(qualifier)), false, qualifier).append('.');
     }
     buf.append("super");
   }

--- a/src/org/jetbrains/java/decompiler/util/token/ClassTextToken.java
+++ b/src/org/jetbrains/java/decompiler/util/token/ClassTextToken.java
@@ -1,0 +1,22 @@
+package org.jetbrains.java.decompiler.util.token;
+
+import org.jetbrains.java.decompiler.main.extern.TextTokenVisitor;
+
+public class ClassTextToken extends TextToken {
+  public final String qualifiedName;
+
+  public ClassTextToken(int start, int length, boolean declaration, String qualifiedName) {
+    super(start, length, declaration);
+    this.qualifiedName = qualifiedName;
+  }
+
+  @Override
+  public ClassTextToken copy() {
+    return new ClassTextToken(start, length, declaration, qualifiedName);
+  }
+
+  @Override
+  public void visit(TextTokenVisitor visitor) {
+    visitor.visitClass(new TextRange(start, length), declaration, qualifiedName);
+  }
+}

--- a/src/org/jetbrains/java/decompiler/util/token/FieldTextToken.java
+++ b/src/org/jetbrains/java/decompiler/util/token/FieldTextToken.java
@@ -1,0 +1,27 @@
+package org.jetbrains.java.decompiler.util.token;
+
+import org.jetbrains.java.decompiler.main.extern.TextTokenVisitor;
+import org.jetbrains.java.decompiler.struct.gen.FieldDescriptor;
+
+public class FieldTextToken extends TextToken {
+  public final String className;
+  public final String name;
+  public final FieldDescriptor descriptor;
+
+  public FieldTextToken(int start, int length, boolean declaration, String className, String name, FieldDescriptor descriptor) {
+    super(start, length, declaration);
+    this.className = className;
+    this.name = name;
+    this.descriptor = descriptor;
+  }
+
+  @Override
+  public FieldTextToken copy() {
+    return new FieldTextToken(start, length, declaration, className, name, descriptor);
+  }
+
+  @Override
+  public void visit(TextTokenVisitor visitor) {
+    visitor.visitField(new TextRange(start, length), declaration, className, name, descriptor);
+  }
+}

--- a/src/org/jetbrains/java/decompiler/util/token/MethodTextToken.java
+++ b/src/org/jetbrains/java/decompiler/util/token/MethodTextToken.java
@@ -1,0 +1,27 @@
+package org.jetbrains.java.decompiler.util.token;
+
+import org.jetbrains.java.decompiler.main.extern.TextTokenVisitor;
+import org.jetbrains.java.decompiler.struct.gen.MethodDescriptor;
+
+public class MethodTextToken extends TextToken {
+  public final String className;
+  public final String name;
+  public final MethodDescriptor descriptor;
+
+  public MethodTextToken(int start, int length, boolean declaration, String className, String name, MethodDescriptor descriptor) {
+    super(start, length, declaration);
+    this.className = className;
+    this.name = name;
+    this.descriptor = descriptor;
+  }
+
+  @Override
+  public MethodTextToken copy() {
+    return new MethodTextToken(start, length, declaration, className, name, descriptor);
+  }
+
+  @Override
+  public void visit(TextTokenVisitor visitor) {
+    visitor.visitMethod(new TextRange(start, length), declaration, className, name, descriptor);
+  }
+}

--- a/src/org/jetbrains/java/decompiler/util/token/TextRange.java
+++ b/src/org/jetbrains/java/decompiler/util/token/TextRange.java
@@ -1,0 +1,15 @@
+package org.jetbrains.java.decompiler.util.token;
+
+public class TextRange {
+  public final int start;
+  public final int length;
+
+  public TextRange(int start, int length) {
+    this.start = start;
+    this.length = length;
+  }
+
+  public int getEnd() {
+    return start + length;
+  }
+}

--- a/src/org/jetbrains/java/decompiler/util/token/TextToken.java
+++ b/src/org/jetbrains/java/decompiler/util/token/TextToken.java
@@ -1,0 +1,35 @@
+package org.jetbrains.java.decompiler.util.token;
+
+import org.jetbrains.java.decompiler.main.extern.TextTokenVisitor;
+
+public abstract class TextToken {
+  protected int start;
+  protected int length;
+  protected boolean declaration;
+
+  public TextToken(int start, int length, boolean declaration) {
+    this.start = start;
+    this.length = length;
+    this.declaration = declaration;
+  }
+
+  public void shift(int amount) {
+    this.start += amount;
+  }
+
+  public abstract TextToken copy();
+
+  public abstract void visit(TextTokenVisitor visitor);
+
+  public int getStart() {
+    return start;
+  }
+
+  public int getLength() {
+    return length;
+  }
+
+  public boolean isDeclaration() {
+    return declaration;
+  }
+}

--- a/src/org/jetbrains/java/decompiler/util/token/TextTokenDumpVisitor.java
+++ b/src/org/jetbrains/java/decompiler/util/token/TextTokenDumpVisitor.java
@@ -8,26 +8,29 @@ import org.jetbrains.java.decompiler.util.TextBuffer;
 
 public class TextTokenDumpVisitor extends TextTokenVisitor {
   private final TextBuffer buffer;
-  private StringBuilder textBuilder;
+  private TextBuffer text;
 
   public TextTokenDumpVisitor(TextTokenVisitor next, TextBuffer buffer) {
     super(next);
     this.buffer = buffer;
   }
 
-  private StringBuilder range(TextRange range) {
-    textBuilder.append("(").append(buffer.getPos(range.start));
-    textBuilder.append(", ").append(buffer.getPos(range.getEnd()));
-    return textBuilder.append(")");
+  private TextBuffer range(TextRange range) {
+    text.append("(").append(buffer.getPos(range.start));
+    text.append(", ").append(buffer.getPos(range.getEnd()));
+    return text.append(")");
   }
 
-  private StringBuilder declaration(boolean declaration) {
-    return textBuilder.append(declaration ? "[declaration]" : "[reference]");
+  private TextBuffer declaration(boolean declaration) {
+    return text.append(declaration ? "[declaration]" : "[reference]");
   }
 
   @Override
   public void start() {
-    textBuilder = new StringBuilder("\n/*\nTokens:");
+    text = new TextBuffer();
+    text.appendLineSeparator()
+      .append("/*").appendLineSeparator()
+      .append("Tokens:").appendLineSeparator();
   }
 
   @Override
@@ -35,7 +38,8 @@ public class TextTokenDumpVisitor extends TextTokenVisitor {
     super.visitClass(range, declaration, name);
     range(range).append(" class ");
     declaration(declaration).append(" ");
-    textBuilder.append(name);
+    text.append(name);
+    text.appendLineSeparator();
   }
 
   @Override
@@ -43,9 +47,10 @@ public class TextTokenDumpVisitor extends TextTokenVisitor {
     super.visitField(range, declaration, className, name, descriptor);
     range(range).append(" field ");
     declaration(declaration).append(" ");
-    textBuilder.append(className);
-    textBuilder.append("#").append(name);
-    textBuilder.append(":").append(descriptor.descriptorString);
+    text.append(className);
+    text.append("#").append(name);
+    text.append(":").append(descriptor.descriptorString);
+    text.appendLineSeparator();
   }
 
   @Override
@@ -53,19 +58,21 @@ public class TextTokenDumpVisitor extends TextTokenVisitor {
     super.visitMethod(range, declaration, className, name, descriptor);
     range(range).append(" method ");
     declaration(declaration).append(" ");
-    textBuilder.append(className);
-    textBuilder.append("#").append(name);
-    textBuilder.append(descriptor.toString());
+    text.append(className);
+    text.append("#").append(name);
+    text.append(descriptor.toString());
+    text.appendLineSeparator();
   }
 
   private void visitVariable(boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, VarType type) {
     declaration(declaration).append(" ");
-    textBuilder.append(className);
-    textBuilder.append("#").append(methodName);
-    textBuilder.append(methodDescriptor.toString());
-    textBuilder.append(":").append(index);
-    textBuilder.append(" ").append(name);
-    textBuilder.append(" ").append(type.toString());
+    text.append(className);
+    text.append("#").append(methodName);
+    text.append(methodDescriptor.toString());
+    text.append(":").append(index);
+    text.append(" ").append(name);
+    text.append(" ").append(type.toString());
+    text.appendLineSeparator();
   }
 
   @Override
@@ -84,7 +91,7 @@ public class TextTokenDumpVisitor extends TextTokenVisitor {
 
   @Override
   public void end() {
-    textBuilder.append("*/");
-    buffer.append(textBuilder.toString());
+    text.append("*/").appendLineSeparator();
+    buffer.append(text.convertToStringAndAllowDataDiscard());
   }
 }

--- a/src/org/jetbrains/java/decompiler/util/token/TextTokenDumpVisitor.java
+++ b/src/org/jetbrains/java/decompiler/util/token/TextTokenDumpVisitor.java
@@ -68,8 +68,8 @@ public class TextTokenDumpVisitor extends TextTokenVisitor {
     text.append(className);
     text.append("#").append(methodName);
     text.append(methodDescriptor.toString());
-    text.append(":").append(index);
-    text.append(" ").append(name);
+    text.append("(").append(index);
+    text.append(":").append(name).append(")");
     text.appendLineSeparator();
   }
 

--- a/src/org/jetbrains/java/decompiler/util/token/TextTokenDumpVisitor.java
+++ b/src/org/jetbrains/java/decompiler/util/token/TextTokenDumpVisitor.java
@@ -1,0 +1,90 @@
+package org.jetbrains.java.decompiler.util.token;
+
+import org.jetbrains.java.decompiler.main.extern.TextTokenVisitor;
+import org.jetbrains.java.decompiler.struct.gen.FieldDescriptor;
+import org.jetbrains.java.decompiler.struct.gen.MethodDescriptor;
+import org.jetbrains.java.decompiler.struct.gen.VarType;
+import org.jetbrains.java.decompiler.util.TextBuffer;
+
+public class TextTokenDumpVisitor extends TextTokenVisitor {
+  private final TextBuffer buffer;
+  private StringBuilder textBuilder;
+
+  public TextTokenDumpVisitor(TextTokenVisitor next, TextBuffer buffer) {
+    super(next);
+    this.buffer = buffer;
+  }
+
+  private StringBuilder range(TextRange range) {
+    textBuilder.append("(").append(buffer.getPos(range.start));
+    textBuilder.append(", ").append(buffer.getPos(range.getEnd()));
+    return textBuilder.append(")");
+  }
+
+  private StringBuilder declaration(boolean declaration) {
+    return textBuilder.append(declaration ? "[declaration]" : "[reference]");
+  }
+
+  @Override
+  public void start() {
+    textBuilder = new StringBuilder("\n/*\nTokens:");
+  }
+
+  @Override
+  public void visitClass(TextRange range, boolean declaration, String name) {
+    super.visitClass(range, declaration, name);
+    range(range).append(" class ");
+    declaration(declaration).append(" ");
+    textBuilder.append(name);
+  }
+
+  @Override
+  public void visitField(TextRange range, boolean declaration, String className, String name, FieldDescriptor descriptor) {
+    super.visitField(range, declaration, className, name, descriptor);
+    range(range).append(" field ");
+    declaration(declaration).append(" ");
+    textBuilder.append(className);
+    textBuilder.append("#").append(name);
+    textBuilder.append(":").append(descriptor.descriptorString);
+  }
+
+  @Override
+  public void visitMethod(TextRange range, boolean declaration, String className, String name, MethodDescriptor descriptor) {
+    super.visitMethod(range, declaration, className, name, descriptor);
+    range(range).append(" method ");
+    declaration(declaration).append(" ");
+    textBuilder.append(className);
+    textBuilder.append("#").append(name);
+    textBuilder.append(descriptor.toString());
+  }
+
+  private void visitVariable(boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, VarType type) {
+    declaration(declaration).append(" ");
+    textBuilder.append(className);
+    textBuilder.append("#").append(methodName);
+    textBuilder.append(methodDescriptor.toString());
+    textBuilder.append(":").append(index);
+    textBuilder.append(" ").append(name);
+    textBuilder.append(" ").append(type.toString());
+  }
+
+  @Override
+  public void visitParameter(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, VarType type) {
+    super.visitParameter(range, declaration, className, methodName, methodDescriptor, index, name, type);
+    range(range).append(" parameter ");
+    visitVariable(declaration, className, methodName, methodDescriptor, index, name, type);
+  }
+
+  @Override
+  public void visitLocal(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, VarType type) {
+    super.visitLocal(range, declaration, className, methodName, methodDescriptor, index, name, type);
+    range(range).append(" local ");
+    visitVariable(declaration, className, methodName, methodDescriptor, index, name, type);
+  }
+
+  @Override
+  public void end() {
+    textBuilder.append("*/");
+    buffer.append(textBuilder.toString());
+  }
+}

--- a/src/org/jetbrains/java/decompiler/util/token/TextTokenDumpVisitor.java
+++ b/src/org/jetbrains/java/decompiler/util/token/TextTokenDumpVisitor.java
@@ -26,7 +26,7 @@ public class TextTokenDumpVisitor extends TextTokenVisitor {
   }
 
   @Override
-  public void start() {
+  public void start(String content) {
     text = new TextBuffer();
     text.appendLineSeparator()
       .append("/*").appendLineSeparator()

--- a/src/org/jetbrains/java/decompiler/util/token/TextTokenDumpVisitor.java
+++ b/src/org/jetbrains/java/decompiler/util/token/TextTokenDumpVisitor.java
@@ -3,7 +3,6 @@ package org.jetbrains.java.decompiler.util.token;
 import org.jetbrains.java.decompiler.main.extern.TextTokenVisitor;
 import org.jetbrains.java.decompiler.struct.gen.FieldDescriptor;
 import org.jetbrains.java.decompiler.struct.gen.MethodDescriptor;
-import org.jetbrains.java.decompiler.struct.gen.VarType;
 import org.jetbrains.java.decompiler.util.TextBuffer;
 
 public class TextTokenDumpVisitor extends TextTokenVisitor {
@@ -64,29 +63,28 @@ public class TextTokenDumpVisitor extends TextTokenVisitor {
     text.appendLineSeparator();
   }
 
-  private void visitVariable(boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, VarType type) {
+  private void visitVariable(boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name) {
     declaration(declaration).append(" ");
     text.append(className);
     text.append("#").append(methodName);
     text.append(methodDescriptor.toString());
     text.append(":").append(index);
     text.append(" ").append(name);
-    text.append(" ").append(type.toString());
     text.appendLineSeparator();
   }
 
   @Override
-  public void visitParameter(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, VarType type) {
-    super.visitParameter(range, declaration, className, methodName, methodDescriptor, index, name, type);
+  public void visitParameter(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name) {
+    super.visitParameter(range, declaration, className, methodName, methodDescriptor, index, name);
     range(range).append(" parameter ");
-    visitVariable(declaration, className, methodName, methodDescriptor, index, name, type);
+    visitVariable(declaration, className, methodName, methodDescriptor, index, name);
   }
 
   @Override
-  public void visitLocal(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, VarType type) {
-    super.visitLocal(range, declaration, className, methodName, methodDescriptor, index, name, type);
+  public void visitLocal(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name) {
+    super.visitLocal(range, declaration, className, methodName, methodDescriptor, index, name);
     range(range).append(" local ");
-    visitVariable(declaration, className, methodName, methodDescriptor, index, name, type);
+    visitVariable(declaration, className, methodName, methodDescriptor, index, name);
   }
 
   @Override

--- a/src/org/jetbrains/java/decompiler/util/token/VariableTextToken.java
+++ b/src/org/jetbrains/java/decompiler/util/token/VariableTextToken.java
@@ -1,0 +1,40 @@
+package org.jetbrains.java.decompiler.util.token;
+
+import org.jetbrains.java.decompiler.main.extern.TextTokenVisitor;
+import org.jetbrains.java.decompiler.struct.gen.MethodDescriptor;
+import org.jetbrains.java.decompiler.struct.gen.VarType;
+
+public class VariableTextToken extends TextToken {
+  public final boolean parameter;
+  public final String className;
+  public final String methodName;
+  public final MethodDescriptor methodDescriptor;
+  public final int index;
+  public final String name;
+  public final VarType type;
+
+  public VariableTextToken(int start, int length, boolean declaration, boolean parameter, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, VarType type) {
+    super(start, length, declaration);
+    this.parameter = parameter;
+    this.className = className;
+    this.methodName = methodName;
+    this.methodDescriptor = methodDescriptor;
+    this.index = index;
+    this.name = name;
+    this.type = type;
+  }
+
+  @Override
+  public VariableTextToken copy() {
+    return new VariableTextToken(start, length, declaration, parameter, className, methodName, methodDescriptor, index, name, type);
+  }
+
+  @Override
+  public void visit(TextTokenVisitor visitor) {
+    if (parameter) {
+      visitor.visitParameter(new TextRange(start, length), declaration, className, methodName, methodDescriptor, index, name, type);
+    } else {
+      visitor.visitLocal(new TextRange(start, length), declaration, className, methodName, methodDescriptor, index, name, type);
+    }
+  }
+}

--- a/src/org/jetbrains/java/decompiler/util/token/VariableTextToken.java
+++ b/src/org/jetbrains/java/decompiler/util/token/VariableTextToken.java
@@ -11,9 +11,8 @@ public class VariableTextToken extends TextToken {
   public final MethodDescriptor methodDescriptor;
   public final int index;
   public final String name;
-  public final VarType type;
 
-  public VariableTextToken(int start, int length, boolean declaration, boolean parameter, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, VarType type) {
+  public VariableTextToken(int start, int length, boolean declaration, boolean parameter, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name) {
     super(start, length, declaration);
     this.parameter = parameter;
     this.className = className;
@@ -21,20 +20,19 @@ public class VariableTextToken extends TextToken {
     this.methodDescriptor = methodDescriptor;
     this.index = index;
     this.name = name;
-    this.type = type;
   }
 
   @Override
   public VariableTextToken copy() {
-    return new VariableTextToken(start, length, declaration, parameter, className, methodName, methodDescriptor, index, name, type);
+    return new VariableTextToken(start, length, declaration, parameter, className, methodName, methodDescriptor, index, name);
   }
 
   @Override
   public void visit(TextTokenVisitor visitor) {
     if (parameter) {
-      visitor.visitParameter(new TextRange(start, length), declaration, className, methodName, methodDescriptor, index, name, type);
+      visitor.visitParameter(new TextRange(start, length), declaration, className, methodName, methodDescriptor, index, name);
     } else {
-      visitor.visitLocal(new TextRange(start, length), declaration, className, methodName, methodDescriptor, index, name, type);
+      visitor.visitLocal(new TextRange(start, length), declaration, className, methodName, methodDescriptor, index, name);
     }
   }
 }

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -136,7 +136,8 @@ public class SingleClassesTest extends SingleClassesTestBase {
       IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1",
       IFernflowerPreferences.INCLUDE_ENTIRE_CLASSPATH, "0",
       IFernflowerPreferences.TERNARY_CONDITIONS, "1",
-      IFernflowerPreferences.FORCE_JSR_INLINE, "1"
+      IFernflowerPreferences.FORCE_JSR_INLINE, "1",
+      IFernflowerPreferences.PREFERRED_LINE_LENGTH, "120"
     );
     // TODO: user renamer class test
   }
@@ -789,5 +790,6 @@ public class SingleClassesTest extends SingleClassesTestBase {
 
   private void registerTextTokens() {
     register(JAVA_8, "TestTextTokens");
+    register(JAVA_16, "TestTextTokens2");
   }
 }

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -127,6 +127,17 @@ public class SingleClassesTest extends SingleClassesTestBase {
       IFernflowerPreferences.DECOMPILE_COMPLEX_CONDYS, "1",
       IFernflowerPreferences.PREFERRED_LINE_LENGTH, "250"
     );
+    registerSet("Text Tokens", this::registerTextTokens,
+      IFernflowerPreferences.DUMP_TEXT_TOKENS, "1",
+      IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1",
+      IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1",
+      IFernflowerPreferences.DUMP_EXCEPTION_ON_ERROR, "0",
+      IFernflowerPreferences.IGNORE_INVALID_BYTECODE, "1",
+      IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1",
+      IFernflowerPreferences.INCLUDE_ENTIRE_CLASSPATH, "0",
+      IFernflowerPreferences.TERNARY_CONDITIONS, "1",
+      IFernflowerPreferences.FORCE_JSR_INLINE, "1"
+    );
     // TODO: user renamer class test
   }
 
@@ -445,7 +456,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatchingWithNull");
 
     register(JAVA_17_PREVIEW, "TestSwitchPatternMatchingFuzz1");
-    
+
     // TODO: non-resugared record patterns reference hidden proxy methods
     register(JAVA_19_PREVIEW, "TestRecordPattern1");
     register(JAVA_19_PREVIEW, "TestRecordPattern2");
@@ -774,5 +785,9 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_8, "TestTryLoopRecompile");
     register(JAVA_8, "TestTryLoopSimpleFinally");
     register(JAVA_8, "TestTryLoopReturnFinally");
+  }
+
+  private void registerTextTokens() {
+    register(JAVA_8, "TestTextTokens");
   }
 }

--- a/testData/results/pkg/TestTextTokens.dec
+++ b/testData/results/pkg/TestTextTokens.dec
@@ -166,21 +166,21 @@ Tokens:
 (12:16, 12:20) method [reference] pkg/TestTextTokens$Bee#buzz()V
 (13:7, 13:13) method [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
 (13:14, 13:20) method [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
-(13:21, 13:22) parameter [declaration] pkg/TestTextTokens#lambda$foo$1(Ljava/lang/String;)Ljava/lang/String;:0 s
+(13:21, 13:22) parameter [declaration] pkg/TestTextTokens#lambda$foo$1(Ljava/lang/String;)Ljava/lang/String;(0:s)
 (13:26, 13:32) method [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
 (13:33, 13:39) method [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
-(13:40, 13:42) parameter [declaration] pkg/TestTextTokens#lambda$null$0(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;:1 s1
-(13:46, 13:48) parameter [reference] pkg/TestTextTokens#lambda$null$0(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;:1 s1
-(13:102, 13:103) parameter [reference] pkg/TestTextTokens#lambda$foo$1(Ljava/lang/String;)Ljava/lang/String;:0 s
-(13:108, 13:109) parameter [reference] pkg/TestTextTokens#lambda$foo$1(Ljava/lang/String;)Ljava/lang/String;:0 s
+(13:40, 13:42) parameter [declaration] pkg/TestTextTokens#lambda$null$0(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;(1:s1)
+(13:46, 13:48) parameter [reference] pkg/TestTextTokens#lambda$null$0(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;(1:s1)
+(13:102, 13:103) parameter [reference] pkg/TestTextTokens#lambda$foo$1(Ljava/lang/String;)Ljava/lang/String;(0:s)
+(13:108, 13:109) parameter [reference] pkg/TestTextTokens#lambda$foo$1(Ljava/lang/String;)Ljava/lang/String;(0:s)
 (14:11, 14:16) method [reference] java/util/function/Function#apply(Ljava/lang/Object;)Ljava/lang/Object;
 (17:24, 17:27) method [declaration] pkg/TestTextTokens#bar(Ljava/lang/String;)V
 (17:28, 17:34) class [reference] java/lang/String
-(17:35, 17:36) parameter [declaration] pkg/TestTextTokens#bar(Ljava/lang/String;)V:0 s
+(17:35, 17:36) parameter [declaration] pkg/TestTextTokens#bar(Ljava/lang/String;)V(0:s)
 (18:7, 18:13) class [reference] java/lang/System
 (18:14, 18:17) field [reference] java/lang/System#out:Ljava/io/PrintStream;
 (18:18, 18:25) method [reference] java/io/PrintStream#println(Ljava/lang/String;)V
-(18:26, 18:27) parameter [reference] pkg/TestTextTokens#bar(Ljava/lang/String;)V:0 s
+(18:26, 18:27) parameter [reference] pkg/TestTextTokens#bar(Ljava/lang/String;)V(0:s)
 (21:19, 21:27) class [reference] java/util/function/Function
 (21:28, 21:34) class [reference] java/lang/String
 (21:36, 21:42) class [reference] java/lang/String
@@ -188,11 +188,11 @@ Tokens:
 (22:7, 22:15) class [reference] java/util/function/Function
 (22:16, 22:22) class [reference] java/lang/String
 (22:24, 22:30) class [reference] java/lang/String
-(22:32, 22:95) parameter [declaration] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;:0 extraLongVariableNameToReachPreferredLineLengthAndCauseWrapping
-(24:14, 24:77) parameter [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;:0 extraLongVariableNameToReachPreferredLineLengthAndCauseWrapping
+(22:32, 22:95) parameter [declaration] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;(0:extraLongVariableNameToReachPreferredLineLengthAndCauseWrapping)
+(24:14, 24:77) parameter [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;(0:extraLongVariableNameToReachPreferredLineLengthAndCauseWrapping)
 (24:78, 24:85) method [reference] java/util/function/Function#andThen(Ljava/util/function/Function;)Ljava/util/function/Function;
-(24:86, 24:89) parameter [declaration] pkg/TestTextTokens#lambda$method$2(Ljava/lang/String;)Ljava/lang/String;:0 str
-(24:93, 24:96) parameter [reference] pkg/TestTextTokens#lambda$method$2(Ljava/lang/String;)Ljava/lang/String;:0 str
+(24:86, 24:89) parameter [declaration] pkg/TestTextTokens#lambda$method$2(Ljava/lang/String;)Ljava/lang/String;(0:str)
+(24:93, 24:96) parameter [reference] pkg/TestTextTokens#lambda$method$2(Ljava/lang/String;)Ljava/lang/String;(0:str)
 (24:97, 24:104) method [reference] java/lang/String#replace(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/lang/String;
 (27:5, 27:15) class [reference] java/lang/Deprecated
 (28:18, 28:21) class [declaration] pkg/TestTextTokens$Bee

--- a/testData/results/pkg/TestTextTokens.dec
+++ b/testData/results/pkg/TestTextTokens.dec
@@ -154,8 +154,11 @@ Lines mapping:
 Tokens:
 (6:2, 6:18) class [reference] pkg/MoreAnnotations$NestedAnnotation
 (7:14, 7:28) class [declaration] pkg/TestTextTokens
-(8:12, 8:30) class [reference] pkg/TestTextTokens$Bee
+(8:12, 8:26) class [reference] pkg/TestTextTokens
+(8:27, 8:30) class [reference] pkg/TestTextTokens$Bee
 (8:31, 8:34) field [declaration] pkg/TestTextTokens#bee:Lpkg/TestTextTokens$Bee;
+(8:41, 8:55) class [reference] pkg/TestTextTokens
+(8:56, 8:59) class [reference] pkg/TestTextTokens$Bee
 (10:16, 10:19) method [declaration] pkg/TestTextTokens#foo()V
 (11:7, 11:10) method [reference] pkg/TestTextTokens#bar(Ljava/lang/String;)V
 (12:12, 12:15) field [reference] pkg/TestTextTokens#bee:Lpkg/TestTextTokens$Bee;

--- a/testData/results/pkg/TestTextTokens.dec
+++ b/testData/results/pkg/TestTextTokens.dec
@@ -165,17 +165,20 @@ Tokens:
 (12:16, 12:20) method [reference] pkg/TestTextTokens$Bee#buzz()V
 (13:7, 13:13) method [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
 (13:14, 13:20) method [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
-(13:21, 13:22) parameter [declaration] pkg/TestTextTokens#lambda$foo$1(Ljava/lang/String;)Ljava/lang/String;:0 s Ljava/lang/String;
+(13:21, 13:22) parameter [declaration] pkg/TestTextTokens#lambda$foo$1(Ljava/lang/String;)Ljava/lang/String;:0 s
 (13:26, 13:32) method [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
 (13:33, 13:39) method [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
-(13:40, 13:42) parameter [declaration] pkg/TestTextTokens#lambda$null$0(Ljava/lang/String;)Ljava/lang/String;:0 s1 Ljava/lang/String;
+(13:40, 13:42) parameter [declaration] pkg/TestTextTokens#lambda$null$0(Ljava/lang/String;)Ljava/lang/String;:0 s1
+(13:46, 13:48) parameter [reference] pkg/TestTextTokens#lambda$null$0(Ljava/lang/String;)Ljava/lang/String;:0 s1
+(13:104, 13:105) parameter [reference] pkg/TestTextTokens#lambda$foo$1(Ljava/lang/String;)Ljava/lang/String;:0 s
 (14:11, 14:16) method [reference] java/util/function/Function#apply(Ljava/lang/Object;)Ljava/lang/Object;
 (17:24, 17:27) method [declaration] pkg/TestTextTokens#bar(Ljava/lang/String;)V
 (17:28, 17:34) class [reference] java/lang/String
-(17:35, 17:36) parameter [declaration] pkg/TestTextTokens#bar(Ljava/lang/String;)V:0 s Ljava/lang/String;
+(17:35, 17:36) parameter [declaration] pkg/TestTextTokens#bar(Ljava/lang/String;)V:0 s
 (18:7, 18:13) class [reference] java/lang/System
 (18:14, 18:17) field [reference] java/lang/System#out:Ljava/io/PrintStream;
 (18:18, 18:25) method [reference] java/io/PrintStream#println(Ljava/lang/String;)V
+(18:26, 18:27) parameter [reference] pkg/TestTextTokens#bar(Ljava/lang/String;)V:0 s
 (21:19, 21:27) class [reference] java/util/function/Function
 (21:28, 21:34) class [reference] java/lang/String
 (21:36, 21:42) class [reference] java/lang/String
@@ -183,9 +186,11 @@ Tokens:
 (22:7, 22:15) class [reference] java/util/function/Function
 (22:16, 22:22) class [reference] java/lang/String
 (22:24, 22:30) class [reference] java/lang/String
-(22:32, 22:95) parameter [declaration] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;:0 extraLongVariableNameToReachPreferredLineLengthAndCauseWrapping Ljava/util/function/Function;<String, String>
+(22:32, 22:95) parameter [declaration] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;:0 extraLongVariableNameToReachPreferredLineLengthAndCauseWrapping
+(24:14, 24:77) parameter [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;:0 extraLongVariableNameToReachPreferredLineLengthAndCauseWrapping
 (24:78, 24:85) method [reference] java/util/function/Function#andThen(Ljava/util/function/Function;)Ljava/util/function/Function;
-(24:86, 24:89) parameter [declaration] pkg/TestTextTokens#lambda$method$2(Ljava/lang/String;)Ljava/lang/String;:0 str Ljava/lang/String;
+(24:86, 24:89) parameter [declaration] pkg/TestTextTokens#lambda$method$2(Ljava/lang/String;)Ljava/lang/String;:0 str
+(24:93, 24:96) parameter [reference] pkg/TestTextTokens#lambda$method$2(Ljava/lang/String;)Ljava/lang/String;:0 str
 (24:97, 24:104) method [reference] java/lang/String#replace(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/lang/String;
 (27:5, 27:15) class [reference] java/lang/Deprecated
 (28:18, 28:21) class [declaration] pkg/TestTextTokens$Bee

--- a/testData/results/pkg/TestTextTokens.dec
+++ b/testData/results/pkg/TestTextTokens.dec
@@ -176,9 +176,13 @@ Tokens:
 (18:7, 18:13) class [reference] java/lang/System
 (18:14, 18:17) field [reference] java/lang/System#out:Ljava/io/PrintStream;
 (18:18, 18:25) method [reference] java/io/PrintStream#println(Ljava/lang/String;)V
-(21:19, 21:43) class [reference] java/util/function/Function
+(21:19, 21:27) class [reference] java/util/function/Function
+(21:28, 21:34) class [reference] java/lang/String
+(21:36, 21:42) class [reference] java/lang/String
 (21:44, 21:50) method [declaration] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
-(22:7, 22:31) class [reference] java/util/function/Function
+(22:7, 22:15) class [reference] java/util/function/Function
+(22:16, 22:22) class [reference] java/lang/String
+(22:24, 22:30) class [reference] java/lang/String
 (22:32, 22:95) parameter [declaration] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;:0 extraLongVariableNameToReachPreferredLineLengthAndCauseWrapping Ljava/util/function/Function;<String, String>
 (24:78, 24:85) method [reference] java/util/function/Function#andThen(Ljava/util/function/Function;)Ljava/util/function/Function;
 (24:86, 24:89) parameter [declaration] pkg/TestTextTokens#lambda$method$2(Ljava/lang/String;)Ljava/lang/String;:0 str Ljava/lang/String;

--- a/testData/results/pkg/TestTextTokens.dec
+++ b/testData/results/pkg/TestTextTokens.dec
@@ -1,0 +1,189 @@
+package pkg;
+
+import java.util.function.Function;
+import pkg.MoreAnnotations.NestedAnnotation;
+
+@NestedAnnotation
+public class TestTextTokens {
+   private TestTextTokens.Bee bee = new TestTextTokens.Bee();
+
+   public void foo() {
+      bar("Hello world");// 10
+      this.bee.buzz();// 11
+      method(method(s -> method(method(s1 -> s1 + " really long string to cause code reformatting")) + s))// 13
+         .apply("Lorem ipsum dolor sit amet");
+   }// 14
+
+   private static void bar(String s) {
+      System.out.println(s);// 17
+   }// 18
+
+   private static Function<String, String> method(
+      Function<String, String> extraLongVariableNameToReachPreferredLineLengthAndCauseWrapping
+   ) {
+      return extraLongVariableNameToReachPreferredLineLengthAndCauseWrapping.andThen(str -> str.replace(" ", ""));// 21
+   }
+
+   @Deprecated
+   private class Bee {
+      private Bee() {
+      }// 25
+
+      public void buzz() {
+         TestTextTokens.bar("bzzz");// 27
+      }// 28
+   }
+}
+
+class 'pkg/TestTextTokens' {
+   method 'foo ()V' {
+      0      10
+      1      10
+      2      10
+      3      10
+      4      10
+      5      11
+      6      11
+      7      11
+      8      11
+      9      11
+      a      11
+      b      11
+      11      12
+      12      12
+      13      12
+      14      12
+      15      12
+      16      12
+      17      13
+      18      13
+      19      13
+      1a      13
+      1b      13
+      1c      13
+      1d      13
+      1f      14
+   }
+
+   method 'lambda$foo$1 (Ljava/lang/String;)Ljava/lang/String;' {
+      c      12
+      d      12
+      e      12
+      f      12
+      10      12
+      11      12
+      15      12
+      19      12
+      1a      12
+      1b      12
+      1c      12
+   }
+
+   method 'lambda$null$0 (Ljava/lang/String;)Ljava/lang/String;' {
+      7      12
+      b      12
+      c      12
+      10      12
+      11      12
+      12      12
+      13      12
+   }
+
+   method 'bar (Ljava/lang/String;)V' {
+      0      17
+      1      17
+      2      17
+      3      17
+      4      17
+      5      17
+      6      17
+      7      18
+   }
+
+   method 'method (Ljava/util/function/Function;)Ljava/util/function/Function;' {
+      0      23
+      6      23
+      7      23
+      8      23
+      9      23
+      a      23
+      b      23
+   }
+
+   method 'lambda$method$2 (Ljava/lang/String;)Ljava/lang/String;' {
+      0      23
+      1      23
+      2      23
+      3      23
+      4      23
+      5      23
+      6      23
+      7      23
+      8      23
+   }
+}
+
+class 'pkg/TestTextTokens$Bee' {
+   method '<init> (Lpkg/TestTextTokens;)V' {
+      9      29
+   }
+
+   method 'buzz ()V' {
+      0      32
+      1      32
+      2      32
+      3      32
+      4      32
+      5      33
+   }
+}
+
+Lines mapping:
+10 <-> 11
+11 <-> 12
+13 <-> 13
+14 <-> 15
+17 <-> 18
+18 <-> 19
+21 <-> 24
+25 <-> 30
+27 <-> 33
+28 <-> 34
+
+/*
+Tokens:
+(6:2, 6:18) class [reference] pkg/MoreAnnotations$NestedAnnotation
+(7:14, 7:28) class [declaration] pkg/TestTextTokens
+(8:12, 8:30) class [reference] pkg/TestTextTokens$Bee
+(8:31, 8:34) field [declaration] pkg/TestTextTokens#bee:Lpkg/TestTextTokens$Bee;
+(10:16, 10:19) method [declaration] pkg/TestTextTokens#foo()V
+(11:7, 11:10) method [reference] pkg/TestTextTokens#bar(Ljava/lang/String;)V
+(12:12, 12:15) field [reference] pkg/TestTextTokens#bee:Lpkg/TestTextTokens$Bee;
+(12:16, 12:20) method [reference] pkg/TestTextTokens$Bee#buzz()V
+(13:7, 13:13) method [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
+(13:14, 13:20) method [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
+(13:21, 13:22) parameter [declaration] pkg/TestTextTokens#lambda$foo$1(Ljava/lang/String;)Ljava/lang/String;:0 s Ljava/lang/String;
+(13:26, 13:32) method [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
+(13:33, 13:39) method [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
+(13:40, 13:42) parameter [declaration] pkg/TestTextTokens#lambda$null$0(Ljava/lang/String;)Ljava/lang/String;:0 s1 Ljava/lang/String;
+(14:11, 14:16) method [reference] java/util/function/Function#apply(Ljava/lang/Object;)Ljava/lang/Object;
+(17:24, 17:27) method [declaration] pkg/TestTextTokens#bar(Ljava/lang/String;)V
+(17:28, 17:34) class [reference] java/lang/String
+(17:35, 17:36) parameter [declaration] pkg/TestTextTokens#bar(Ljava/lang/String;)V:0 s Ljava/lang/String;
+(18:7, 18:13) class [reference] java/lang/System
+(18:14, 18:17) field [reference] java/lang/System#out:Ljava/io/PrintStream;
+(18:18, 18:25) method [reference] java/io/PrintStream#println(Ljava/lang/String;)V
+(21:19, 21:43) class [reference] java/util/function/Function
+(21:44, 21:50) method [declaration] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
+(22:7, 22:31) class [reference] java/util/function/Function
+(22:32, 22:95) parameter [declaration] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;:0 extraLongVariableNameToReachPreferredLineLengthAndCauseWrapping Ljava/util/function/Function;<String, String>
+(24:78, 24:85) method [reference] java/util/function/Function#andThen(Ljava/util/function/Function;)Ljava/util/function/Function;
+(24:86, 24:89) parameter [declaration] pkg/TestTextTokens#lambda$method$2(Ljava/lang/String;)Ljava/lang/String;:0 str Ljava/lang/String;
+(24:97, 24:104) method [reference] java/lang/String#replace(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/lang/String;
+(27:5, 27:15) class [reference] java/lang/Deprecated
+(28:18, 28:21) class [declaration] pkg/TestTextTokens$Bee
+(29:15, 29:18) method [declaration] pkg/TestTextTokens$Bee#<init>(Lpkg/TestTextTokens;)V
+(32:19, 32:23) method [declaration] pkg/TestTextTokens$Bee#buzz()V
+(33:10, 33:24) class [reference] pkg/TestTextTokens
+(33:25, 33:28) method [reference] pkg/TestTextTokens#bar(Ljava/lang/String;)V
+*/

--- a/testData/results/pkg/TestTextTokens.dec
+++ b/testData/results/pkg/TestTextTokens.dec
@@ -10,7 +10,7 @@ public class TestTextTokens {
    public void foo() {
       bar("Hello world");// 10
       this.bee.buzz();// 11
-      method(method(s -> method(method(s1 -> s1 + " really long string to cause code reformatting")) + s))// 13
+      method(method(s -> method(method(s1 -> s1 + " really long string to cause code reformatting" + s)) + s))// 13
          .apply("Lorem ipsum dolor sit amet");
    }// 14
 
@@ -66,27 +66,28 @@ class 'pkg/TestTextTokens' {
    }
 
    method 'lambda$foo$1 (Ljava/lang/String;)Ljava/lang/String;' {
-      c      12
       d      12
       e      12
       f      12
       10      12
       11      12
-      15      12
-      19      12
+      12      12
+      16      12
       1a      12
       1b      12
       1c      12
+      1d      12
    }
 
-   method 'lambda$null$0 (Ljava/lang/String;)Ljava/lang/String;' {
+   method 'lambda$null$0 (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;' {
       7      12
       b      12
       c      12
       10      12
-      11      12
-      12      12
-      13      12
+      14      12
+      15      12
+      16      12
+      17      12
    }
 
    method 'bar (Ljava/lang/String;)V' {
@@ -168,9 +169,10 @@ Tokens:
 (13:21, 13:22) parameter [declaration] pkg/TestTextTokens#lambda$foo$1(Ljava/lang/String;)Ljava/lang/String;:0 s
 (13:26, 13:32) method [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
 (13:33, 13:39) method [reference] pkg/TestTextTokens#method(Ljava/util/function/Function;)Ljava/util/function/Function;
-(13:40, 13:42) parameter [declaration] pkg/TestTextTokens#lambda$null$0(Ljava/lang/String;)Ljava/lang/String;:0 s1
-(13:46, 13:48) parameter [reference] pkg/TestTextTokens#lambda$null$0(Ljava/lang/String;)Ljava/lang/String;:0 s1
-(13:104, 13:105) parameter [reference] pkg/TestTextTokens#lambda$foo$1(Ljava/lang/String;)Ljava/lang/String;:0 s
+(13:40, 13:42) parameter [declaration] pkg/TestTextTokens#lambda$null$0(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;:1 s1
+(13:46, 13:48) parameter [reference] pkg/TestTextTokens#lambda$null$0(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;:1 s1
+(13:102, 13:103) parameter [reference] pkg/TestTextTokens#lambda$foo$1(Ljava/lang/String;)Ljava/lang/String;:0 s
+(13:108, 13:109) parameter [reference] pkg/TestTextTokens#lambda$foo$1(Ljava/lang/String;)Ljava/lang/String;:0 s
 (14:11, 14:16) method [reference] java/util/function/Function#apply(Ljava/lang/Object;)Ljava/lang/Object;
 (17:24, 17:27) method [declaration] pkg/TestTextTokens#bar(Ljava/lang/String;)V
 (17:28, 17:34) class [reference] java/lang/String

--- a/testData/results/pkg/TestTextTokens2.dec
+++ b/testData/results/pkg/TestTextTokens2.dec
@@ -114,5 +114,5 @@ Tokens:
 (15:42, 15:43) parameter [reference] pkg/TestTextTokens2#lambda$bar$0(Ljava/lang/String;Ljava/util/function/BiConsumer;)V:2 c
 (15:44, 15:50) method [reference] java/util/function/BiConsumer#accept(Ljava/lang/Object;Ljava/lang/Object;)V
 (15:56, 15:61) field [reference] pkg/TestTextTokens2#value:Ljava/lang/Object;
-(15:63, 15:64) parameter [reference] pkg/TestTextTokens2#lambda$bar$0(Ljava/lang/String;Ljava/util/function/BiConsumer;)V:1 s
+(15:63, 15:64) local [reference] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V:2 s
 */

--- a/testData/results/pkg/TestTextTokens2.dec
+++ b/testData/results/pkg/TestTextTokens2.dec
@@ -2,7 +2,7 @@ package pkg;
 
 import ext.ExampleAnnotation;
 import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 public record TestTextTokens2<T>(String name, @ExampleAnnotation T value, int index, Object... args) {
@@ -10,9 +10,10 @@ public record TestTextTokens2<T>(String name, @ExampleAnnotation T value, int in
       System.out.println(this.name + ": " + this.value);// 11
    }// 12
 
-   public void bar(Supplier<Optional<? extends Consumer<T>>> r) {
-      ((Optional)r.get()).ifPresent(c -> c.accept(this.value));// 15
-   }// 16
+   public void bar(Supplier<Optional<? extends BiConsumer<T, String>>> r) {
+      String s = "Hello world";// 15
+      ((Optional)r.get()).ifPresent(c -> c.accept(this.value, s));// 16
+   }// 17
 }
 
 class 'pkg/TestTextTokens2' {
@@ -43,30 +44,34 @@ class 'pkg/TestTextTokens2' {
       0      13
       1      13
       2      13
-      3      13
-      4      13
-      5      13
-      6      13
-      7      13
-      8      13
-      f      13
-      10      13
-      11      13
-      12      14
+      3      14
+      4      14
+      5      14
+      6      14
+      7      14
+      8      14
+      9      14
+      a      14
+      b      14
+      13      14
+      14      14
+      15      14
+      16      15
    }
 
-   method 'lambda$bar$0 (Ljava/util/function/Consumer;)V' {
-      0      13
-      1      13
-      2      13
-      3      13
-      4      13
-      5      13
-      6      13
-      7      13
-      8      13
-      9      13
-      a      13
+   method 'lambda$bar$0 (Ljava/lang/String;Ljava/util/function/BiConsumer;)V' {
+      0      14
+      1      14
+      2      14
+      3      14
+      4      14
+      5      14
+      6      14
+      7      14
+      8      14
+      9      14
+      a      14
+      b      14
    }
 }
 
@@ -75,6 +80,7 @@ Lines mapping:
 12 <-> 11
 15 <-> 14
 16 <-> 15
+17 <-> 16
 
 /*
 Tokens:
@@ -95,14 +101,18 @@ Tokens:
 (13:16, 13:19) method [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V
 (13:20, 13:28) class [reference] java/util/function/Supplier
 (13:29, 13:37) class [reference] java/util/Optional
-(13:48, 13:56) class [reference] java/util/function/Consumer
-(13:62, 13:63) parameter [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V:1 r
-(14:9, 14:17) class [reference] java/util/Optional
-(14:18, 14:19) parameter [reference] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V:1 r
-(14:20, 14:23) method [reference] java/util/function/Supplier#get()Ljava/lang/Object;
-(14:27, 14:36) method [reference] java/util/Optional#ifPresent(Ljava/util/function/Consumer;)V
-(14:37, 14:38) parameter [declaration] pkg/TestTextTokens2#lambda$bar$0(Ljava/util/function/Consumer;)V:1 c
-(14:42, 14:43) parameter [reference] pkg/TestTextTokens2#lambda$bar$0(Ljava/util/function/Consumer;)V:1 c
-(14:44, 14:50) method [reference] java/util/function/Consumer#accept(Ljava/lang/Object;)V
-(14:56, 14:61) field [reference] pkg/TestTextTokens2#value:Ljava/lang/Object;
+(13:48, 13:58) class [reference] java/util/function/BiConsumer
+(13:61, 13:67) class [reference] java/lang/String
+(13:72, 13:73) parameter [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V:1 r
+(14:7, 14:13) class [reference] java/lang/String
+(14:14, 14:15) local [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V:2 s
+(15:9, 15:17) class [reference] java/util/Optional
+(15:18, 15:19) parameter [reference] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V:1 r
+(15:20, 15:23) method [reference] java/util/function/Supplier#get()Ljava/lang/Object;
+(15:27, 15:36) method [reference] java/util/Optional#ifPresent(Ljava/util/function/Consumer;)V
+(15:37, 15:38) parameter [declaration] pkg/TestTextTokens2#lambda$bar$0(Ljava/lang/String;Ljava/util/function/BiConsumer;)V:2 c
+(15:42, 15:43) parameter [reference] pkg/TestTextTokens2#lambda$bar$0(Ljava/lang/String;Ljava/util/function/BiConsumer;)V:2 c
+(15:44, 15:50) method [reference] java/util/function/BiConsumer#accept(Ljava/lang/Object;Ljava/lang/Object;)V
+(15:56, 15:61) field [reference] pkg/TestTextTokens2#value:Ljava/lang/Object;
+(15:63, 15:64) parameter [reference] pkg/TestTextTokens2#lambda$bar$0(Ljava/lang/String;Ljava/util/function/BiConsumer;)V:1 s
 */

--- a/testData/results/pkg/TestTextTokens2.dec
+++ b/testData/results/pkg/TestTextTokens2.dec
@@ -1,0 +1,56 @@
+package pkg;
+
+import ext.ExampleAnnotation;
+
+public record TestTextTokens2<T>(String name, @ExampleAnnotation T value, int index, Object... args) {
+   public void foo() {
+      System.out.println(this.name + ": " + this.value);// 7
+   }// 8
+}
+
+class 'pkg/TestTextTokens2' {
+   method 'foo ()V' {
+      0      6
+      1      6
+      2      6
+      3      6
+      4      6
+      5      6
+      6      6
+      7      6
+      8      6
+      9      6
+      a      6
+      b      6
+      c      6
+      d      6
+      e      6
+      f      6
+      10      6
+      11      6
+      12      6
+      13      7
+   }
+}
+
+Lines mapping:
+7 <-> 7
+8 <-> 8
+
+/*
+Tokens:
+(5:15, 5:30) class [declaration] pkg/TestTextTokens2
+(5:34, 5:40) class [reference] java/lang/String
+(5:41, 5:45) field [declaration] pkg/TestTextTokens2#name:Ljava/lang/String;
+(5:48, 5:65) class [reference] ext/ExampleAnnotation
+(5:68, 5:73) field [declaration] pkg/TestTextTokens2#value:Ljava/lang/Object;
+(5:79, 5:84) field [declaration] pkg/TestTextTokens2#index:I
+(5:86, 5:92) class [reference] java/lang/Object
+(5:96, 5:100) field [declaration] pkg/TestTextTokens2#args:[Ljava/lang/Object;
+(6:16, 6:19) method [declaration] pkg/TestTextTokens2#foo()V
+(7:7, 7:13) class [reference] java/lang/System
+(7:14, 7:17) field [reference] java/lang/System#out:Ljava/io/PrintStream;
+(7:18, 7:25) method [reference] java/io/PrintStream#println(Ljava/lang/String;)V
+(7:31, 7:35) field [reference] pkg/TestTextTokens2#name:Ljava/lang/String;
+(7:50, 7:55) field [reference] pkg/TestTextTokens2#value:Ljava/lang/Object;
+*/

--- a/testData/results/pkg/TestTextTokens2.dec
+++ b/testData/results/pkg/TestTextTokens2.dec
@@ -103,16 +103,16 @@ Tokens:
 (13:29, 13:37) class [reference] java/util/Optional
 (13:48, 13:58) class [reference] java/util/function/BiConsumer
 (13:61, 13:67) class [reference] java/lang/String
-(13:72, 13:73) parameter [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V:1 r
+(13:72, 13:73) parameter [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V(1:r)
 (14:7, 14:13) class [reference] java/lang/String
-(14:14, 14:15) local [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V:2 s
+(14:14, 14:15) local [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V(2:s)
 (15:9, 15:17) class [reference] java/util/Optional
-(15:18, 15:19) parameter [reference] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V:1 r
+(15:18, 15:19) parameter [reference] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V(1:r)
 (15:20, 15:23) method [reference] java/util/function/Supplier#get()Ljava/lang/Object;
 (15:27, 15:36) method [reference] java/util/Optional#ifPresent(Ljava/util/function/Consumer;)V
-(15:37, 15:38) parameter [declaration] pkg/TestTextTokens2#lambda$bar$0(Ljava/lang/String;Ljava/util/function/BiConsumer;)V:2 c
-(15:42, 15:43) parameter [reference] pkg/TestTextTokens2#lambda$bar$0(Ljava/lang/String;Ljava/util/function/BiConsumer;)V:2 c
+(15:37, 15:38) parameter [declaration] pkg/TestTextTokens2#lambda$bar$0(Ljava/lang/String;Ljava/util/function/BiConsumer;)V(2:c)
+(15:42, 15:43) parameter [reference] pkg/TestTextTokens2#lambda$bar$0(Ljava/lang/String;Ljava/util/function/BiConsumer;)V(2:c)
 (15:44, 15:50) method [reference] java/util/function/BiConsumer#accept(Ljava/lang/Object;Ljava/lang/Object;)V
 (15:56, 15:61) field [reference] pkg/TestTextTokens2#value:Ljava/lang/Object;
-(15:63, 15:64) local [reference] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V:2 s
+(15:63, 15:64) local [reference] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V(2:s)
 */

--- a/testData/results/pkg/TestTextTokens2.dec
+++ b/testData/results/pkg/TestTextTokens2.dec
@@ -96,11 +96,13 @@ Tokens:
 (13:20, 13:28) class [reference] java/util/function/Supplier
 (13:29, 13:37) class [reference] java/util/Optional
 (13:48, 13:56) class [reference] java/util/function/Consumer
-(13:62, 13:63) parameter [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V:1 r Ljava/util/function/Supplier;<Optional<? extends Consumer<T>>>
+(13:62, 13:63) parameter [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V:1 r
 (14:9, 14:17) class [reference] java/util/Optional
+(14:18, 14:19) parameter [reference] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V:1 r
 (14:20, 14:23) method [reference] java/util/function/Supplier#get()Ljava/lang/Object;
 (14:27, 14:36) method [reference] java/util/Optional#ifPresent(Ljava/util/function/Consumer;)V
-(14:37, 14:38) parameter [declaration] pkg/TestTextTokens2#lambda$bar$0(Ljava/util/function/Consumer;)V:1 c Ljava/util/function/Consumer;
+(14:37, 14:38) parameter [declaration] pkg/TestTextTokens2#lambda$bar$0(Ljava/util/function/Consumer;)V:1 c
+(14:42, 14:43) parameter [reference] pkg/TestTextTokens2#lambda$bar$0(Ljava/util/function/Consumer;)V:1 c
 (14:44, 14:50) method [reference] java/util/function/Consumer#accept(Ljava/lang/Object;)V
 (14:56, 14:61) field [reference] pkg/TestTextTokens2#value:Ljava/lang/Object;
 */

--- a/testData/results/pkg/TestTextTokens2.dec
+++ b/testData/results/pkg/TestTextTokens2.dec
@@ -1,56 +1,106 @@
 package pkg;
 
 import ext.ExampleAnnotation;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 public record TestTextTokens2<T>(String name, @ExampleAnnotation T value, int index, Object... args) {
    public void foo() {
-      System.out.println(this.name + ": " + this.value);// 7
-   }// 8
+      System.out.println(this.name + ": " + this.value);// 11
+   }// 12
+
+   public void bar(Supplier<Optional<? extends Consumer<T>>> r) {
+      ((Optional)r.get()).ifPresent(c -> c.accept(this.value));// 15
+   }// 16
 }
 
 class 'pkg/TestTextTokens2' {
    method 'foo ()V' {
-      0      6
-      1      6
-      2      6
-      3      6
-      4      6
-      5      6
-      6      6
-      7      6
-      8      6
-      9      6
-      a      6
-      b      6
-      c      6
-      d      6
-      e      6
-      f      6
-      10      6
-      11      6
-      12      6
-      13      7
+      0      9
+      1      9
+      2      9
+      3      9
+      4      9
+      5      9
+      6      9
+      7      9
+      8      9
+      9      9
+      a      9
+      b      9
+      c      9
+      d      9
+      e      9
+      f      9
+      10      9
+      11      9
+      12      9
+      13      10
+   }
+
+   method 'bar (Ljava/util/function/Supplier;)V' {
+      0      13
+      1      13
+      2      13
+      3      13
+      4      13
+      5      13
+      6      13
+      7      13
+      8      13
+      f      13
+      10      13
+      11      13
+      12      14
+   }
+
+   method 'lambda$bar$0 (Ljava/util/function/Consumer;)V' {
+      0      13
+      1      13
+      2      13
+      3      13
+      4      13
+      5      13
+      6      13
+      7      13
+      8      13
+      9      13
+      a      13
    }
 }
 
 Lines mapping:
-7 <-> 7
-8 <-> 8
+11 <-> 10
+12 <-> 11
+15 <-> 14
+16 <-> 15
 
 /*
 Tokens:
-(5:15, 5:30) class [declaration] pkg/TestTextTokens2
-(5:34, 5:40) class [reference] java/lang/String
-(5:41, 5:45) field [declaration] pkg/TestTextTokens2#name:Ljava/lang/String;
-(5:48, 5:65) class [reference] ext/ExampleAnnotation
-(5:68, 5:73) field [declaration] pkg/TestTextTokens2#value:Ljava/lang/Object;
-(5:79, 5:84) field [declaration] pkg/TestTextTokens2#index:I
-(5:86, 5:92) class [reference] java/lang/Object
-(5:96, 5:100) field [declaration] pkg/TestTextTokens2#args:[Ljava/lang/Object;
-(6:16, 6:19) method [declaration] pkg/TestTextTokens2#foo()V
-(7:7, 7:13) class [reference] java/lang/System
-(7:14, 7:17) field [reference] java/lang/System#out:Ljava/io/PrintStream;
-(7:18, 7:25) method [reference] java/io/PrintStream#println(Ljava/lang/String;)V
-(7:31, 7:35) field [reference] pkg/TestTextTokens2#name:Ljava/lang/String;
-(7:50, 7:55) field [reference] pkg/TestTextTokens2#value:Ljava/lang/Object;
+(8:15, 8:30) class [declaration] pkg/TestTextTokens2
+(8:34, 8:40) class [reference] java/lang/String
+(8:41, 8:45) field [declaration] pkg/TestTextTokens2#name:Ljava/lang/String;
+(8:48, 8:65) class [reference] ext/ExampleAnnotation
+(8:68, 8:73) field [declaration] pkg/TestTextTokens2#value:Ljava/lang/Object;
+(8:79, 8:84) field [declaration] pkg/TestTextTokens2#index:I
+(8:86, 8:92) class [reference] java/lang/Object
+(8:96, 8:100) field [declaration] pkg/TestTextTokens2#args:[Ljava/lang/Object;
+(9:16, 9:19) method [declaration] pkg/TestTextTokens2#foo()V
+(10:7, 10:13) class [reference] java/lang/System
+(10:14, 10:17) field [reference] java/lang/System#out:Ljava/io/PrintStream;
+(10:18, 10:25) method [reference] java/io/PrintStream#println(Ljava/lang/String;)V
+(10:31, 10:35) field [reference] pkg/TestTextTokens2#name:Ljava/lang/String;
+(10:50, 10:55) field [reference] pkg/TestTextTokens2#value:Ljava/lang/Object;
+(13:16, 13:19) method [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V
+(13:20, 13:28) class [reference] java/util/function/Supplier
+(13:29, 13:37) class [reference] java/util/Optional
+(13:48, 13:56) class [reference] java/util/function/Consumer
+(13:62, 13:63) parameter [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V:1 r Ljava/util/function/Supplier;<Optional<? extends Consumer<T>>>
+(14:9, 14:17) class [reference] java/util/Optional
+(14:20, 14:23) method [reference] java/util/function/Supplier#get()Ljava/lang/Object;
+(14:27, 14:36) method [reference] java/util/Optional#ifPresent(Ljava/util/function/Consumer;)V
+(14:37, 14:38) parameter [declaration] pkg/TestTextTokens2#lambda$bar$0(Ljava/util/function/Consumer;)V:1 c Ljava/util/function/Consumer;
+(14:44, 14:50) method [reference] java/util/function/Consumer#accept(Ljava/lang/Object;)V
+(14:56, 14:61) field [reference] pkg/TestTextTokens2#value:Ljava/lang/Object;
 */

--- a/testData/src/java16/ext/ExampleAnnotation.java
+++ b/testData/src/java16/ext/ExampleAnnotation.java
@@ -1,0 +1,4 @@
+package ext;
+
+public @interface ExampleAnnotation {
+}

--- a/testData/src/java16/pkg/TestTextTokens2.java
+++ b/testData/src/java16/pkg/TestTextTokens2.java
@@ -1,0 +1,9 @@
+package pkg;
+
+import ext.ExampleAnnotation;
+
+public record TestTextTokens2<T>(String name, @ExampleAnnotation T value, int index, Object... args) {
+  public void foo() {
+    System.out.println(name + ": " + value);
+  }
+}

--- a/testData/src/java16/pkg/TestTextTokens2.java
+++ b/testData/src/java16/pkg/TestTextTokens2.java
@@ -2,8 +2,16 @@ package pkg;
 
 import ext.ExampleAnnotation;
 
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
 public record TestTextTokens2<T>(String name, @ExampleAnnotation T value, int index, Object... args) {
   public void foo() {
     System.out.println(name + ": " + value);
+  }
+
+  public void bar(Supplier<Optional<? extends Consumer<T>>> r) {
+    r.get().ifPresent(c -> c.accept(value));
   }
 }

--- a/testData/src/java16/pkg/TestTextTokens2.java
+++ b/testData/src/java16/pkg/TestTextTokens2.java
@@ -3,7 +3,7 @@ package pkg;
 import ext.ExampleAnnotation;
 
 import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 public record TestTextTokens2<T>(String name, @ExampleAnnotation T value, int index, Object... args) {
@@ -11,7 +11,8 @@ public record TestTextTokens2<T>(String name, @ExampleAnnotation T value, int in
     System.out.println(name + ": " + value);
   }
 
-  public void bar(Supplier<Optional<? extends Consumer<T>>> r) {
-    r.get().ifPresent(c -> c.accept(value));
+  public void bar(Supplier<Optional<? extends BiConsumer<T, String>>> r) {
+    String s = "Hello world";
+    r.get().ifPresent(c -> c.accept(value, s));
   }
 }

--- a/testData/src/java8/pkg/TestTextTokens.java
+++ b/testData/src/java8/pkg/TestTextTokens.java
@@ -2,6 +2,7 @@ package pkg;
 
 import java.util.function.Function;
 
+@MoreAnnotations.NestedAnnotation
 public class TestTextTokens {
   private Bee bee = new Bee();
 

--- a/testData/src/java8/pkg/TestTextTokens.java
+++ b/testData/src/java8/pkg/TestTextTokens.java
@@ -10,7 +10,7 @@ public class TestTextTokens {
     bar("Hello world");
     bee.buzz();
 
-    method(method(s -> method(method(s1 -> s1 + " really long string to cause code reformatting")) + s)).apply("Lorem ipsum dolor sit amet");
+    method(method(s -> method(method(s1 -> s1 + " really long string to cause code reformatting" + s)) + s)).apply("Lorem ipsum dolor sit amet");
   }
 
   private static void bar(String s) {

--- a/testData/src/java8/pkg/TestTextTokens.java
+++ b/testData/src/java8/pkg/TestTextTokens.java
@@ -1,0 +1,29 @@
+package pkg;
+
+import java.util.function.Function;
+
+public class TestTextTokens {
+  private Bee bee = new Bee();
+
+  public void foo() {
+    bar("Hello world");
+    bee.buzz();
+
+    method(method(s -> method(method(s1 -> s1 + " really long string to cause code reformatting")) + s)).apply("Lorem ipsum dolor sit amet");
+  }
+
+  private static void bar(String s) {
+    System.out.println(s);
+  }
+
+  private static Function<String, String> method(Function<String, String> extraLongVariableNameToReachPreferredLineLengthAndCauseWrapping) {
+    return extraLongVariableNameToReachPreferredLineLengthAndCauseWrapping.andThen(str -> str.replace(" ", ""));
+  }
+
+  @Deprecated
+  private class Bee {
+    public void buzz() {
+      bar("bzzz");
+    }
+  }
+}


### PR DESCRIPTION
While the api part is finished, the implementation still needs work, particularly with implementing tokenization in every place it should be used. It also needs more tests. The option `dtt` (Dump Text Tokens) was added for debugging/testing purposes

As for the api: It's visitor based, and programs may add visitors with `TextTokenVisitor.addVisitor`. 