### PR TITLE
fix(struct): Correctly re-enter badly placed classes into the context map

### DIFF
--- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
+++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
@@ -92,8 +92,10 @@ public class StructContext {
       return null;
     } else {
       final var correctedName = this.badlyPlacedClasses.remove(name);
+      // Correct the class location
       if (correctedName != null) {
         this.classes.put(correctedName, ret);
+        this.classes.remove(name);
       }
       return ret;
     }


### PR DESCRIPTION
(this is untested in the CLI because I didn't have anything handy, but doesn't cause any test failures)

This isn't really an entire fix for improperly placed *library* classes, but it will move the classes that will actually be decompiled.