### PR TITLE
add "warn about inconsistent generic signatures" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The rest of options can be left as they are: they are aimed at professional reve
 - thr: maximum number of threads (default is number of threads available to the JVM)
 - jvn (0): Use jad variable naming for local variables
 - sef (0): Skip copying non-class files from the input folder or file to the output
+- wgs (1): Warn about inconsistent generic signatures
 - win (1): Warn about inconsistent inner class attributes
 - dbe (1): Dump bytecode on errors
 - dee (1): Dump exceptions on errors

--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
@@ -230,6 +230,10 @@ public interface IFernflowerPreferences {
   @Description("Skip copying non-class files from the input folder or file to the output")
   String SKIP_EXTRA_FILES = "sef";
 
+  @Name("Warn about inconsistent generic signatures")
+  @Description("Warn about inconsistent generic signatures")
+  String WARN_INCONSISTENT_GENERIC_SIGNATURES = "wgs";
+
   @Name("Warn about inconsistent inner attributes")
   @Description("Warn about inconsistent inner class attributes")
   String WARN_INCONSISTENT_INNER_CLASSES = "win";
@@ -328,6 +332,7 @@ public interface IFernflowerPreferences {
     defaults.put(THREADS, String.valueOf(Runtime.getRuntime().availableProcessors()));
     defaults.put(USE_JAD_VARNAMING, "0");
     defaults.put(SKIP_EXTRA_FILES, "0");
+    defaults.put(WARN_INCONSISTENT_GENERIC_SIGNATURES, "1");
     defaults.put(WARN_INCONSISTENT_INNER_CLASSES, "1");
     defaults.put(DUMP_BYTECODE_ON_ERROR, "1");
     defaults.put(DUMP_EXCEPTION_ON_ERROR, "1");

--- a/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
+++ b/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
@@ -106,8 +106,10 @@ public final class MethodDescriptor {
           }
         }
         if (actualParams != sig.parameterTypes.size()) {
-          String message = "Inconsistent generic signature in method " + struct.getName() + " " + struct.getDescriptor() + " in " + struct.getClassQualifiedName();
-          DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.WARN);
+          if (DecompilerContext.getOption(IFernflowerPreferences.WARN_INCONSISTENT_GENERIC_SIGNATURES)) {
+            String message = "Inconsistent generic signature in method " + struct.getName() + " " + struct.getDescriptor() + " in " + struct.getClassQualifiedName();
+            DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.WARN);
+          }
           sig = null;
         }
       }


### PR DESCRIPTION
~~This is required for QM to generate MC source without warnings cluttering the logs.~~ Fixed in a different area! I tested and seems to work fine.