### PR TITLE
fix improper offset with generics

### DIFF
--- a/src/org/jetbrains/java/decompiler/util/TextBuffer.java
+++ b/src/org/jetbrains/java/decompiler/util/TextBuffer.java
@@ -187,7 +187,9 @@ public class TextBuffer {
         if (gt.type == CodeConstants.TYPE_OBJECT) {
           addAllClassTokens(index + offset, name, gt.value);
         }
+
         addGenericTypeTokens(index + offset, name, gt);
+        offset += name.length();
       } else {
         if (t.type == CodeConstants.TYPE_OBJECT) {
           addTypeNameToken(t, index + offset);

--- a/testData/results/pkg/TestTextTokens2.dec
+++ b/testData/results/pkg/TestTextTokens2.dec
@@ -3,116 +3,147 @@ package pkg;
 import ext.ExampleAnnotation;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public record TestTextTokens2<T>(String name, @ExampleAnnotation T value, int index, Object... args) {
    public void foo() {
-      System.out.println(this.name + ": " + this.value);// 11
-   }// 12
+      System.out.println(this.name + ": " + this.value);// 12
+   }// 13
 
    public void bar(Supplier<Optional<? extends BiConsumer<T, String>>> r) {
-      String s = "Hello world";// 15
-      ((Optional)r.get()).ifPresent(c -> c.accept(this.value, s));// 16
-   }// 17
+      String s = "Hello world";// 16
+      ((Optional)r.get()).ifPresent(c -> c.accept(this.value, s));// 17
+   }// 18
+
+   public Function<String, String> baz() {
+      return s -> s + " " + this.name;// 21
+   }
 }
 
 class 'pkg/TestTextTokens2' {
    method 'foo ()V' {
-      0      9
-      1      9
-      2      9
-      3      9
-      4      9
-      5      9
-      6      9
-      7      9
-      8      9
-      9      9
-      a      9
-      b      9
-      c      9
-      d      9
-      e      9
-      f      9
-      10      9
-      11      9
-      12      9
-      13      10
+      0      10
+      1      10
+      2      10
+      3      10
+      4      10
+      5      10
+      6      10
+      7      10
+      8      10
+      9      10
+      a      10
+      b      10
+      c      10
+      d      10
+      e      10
+      f      10
+      10      10
+      11      10
+      12      10
+      13      11
    }
 
    method 'bar (Ljava/util/function/Supplier;)V' {
-      0      13
-      1      13
-      2      13
-      3      14
-      4      14
-      5      14
-      6      14
-      7      14
-      8      14
-      9      14
-      a      14
-      b      14
-      13      14
-      14      14
-      15      14
-      16      15
-   }
-
-   method 'lambda$bar$0 (Ljava/lang/String;Ljava/util/function/BiConsumer;)V' {
       0      14
       1      14
       2      14
-      3      14
-      4      14
-      5      14
-      6      14
-      7      14
-      8      14
-      9      14
-      a      14
-      b      14
+      3      15
+      4      15
+      5      15
+      6      15
+      7      15
+      8      15
+      9      15
+      a      15
+      b      15
+      13      15
+      14      15
+      15      15
+      16      16
+   }
+
+   method 'lambda$bar$0 (Ljava/lang/String;Ljava/util/function/BiConsumer;)V' {
+      0      15
+      1      15
+      2      15
+      3      15
+      4      15
+      5      15
+      6      15
+      7      15
+      8      15
+      9      15
+      a      15
+      b      15
+   }
+
+   method 'baz ()Ljava/util/function/Function;' {
+      6      19
+   }
+
+   method 'lambda$baz$1 (Ljava/lang/String;)Ljava/lang/String;' {
+      0      19
+      1      19
+      2      19
+      3      19
+      4      19
+      5      19
+      6      19
+      7      19
+      8      19
+      9      19
+      a      19
    }
 }
 
 Lines mapping:
-11 <-> 10
 12 <-> 11
-15 <-> 14
+13 <-> 12
 16 <-> 15
 17 <-> 16
+18 <-> 17
+21 <-> 20
 
 /*
 Tokens:
-(8:15, 8:30) class [declaration] pkg/TestTextTokens2
-(8:34, 8:40) class [reference] java/lang/String
-(8:41, 8:45) field [declaration] pkg/TestTextTokens2#name:Ljava/lang/String;
-(8:48, 8:65) class [reference] ext/ExampleAnnotation
-(8:68, 8:73) field [declaration] pkg/TestTextTokens2#value:Ljava/lang/Object;
-(8:79, 8:84) field [declaration] pkg/TestTextTokens2#index:I
-(8:86, 8:92) class [reference] java/lang/Object
-(8:96, 8:100) field [declaration] pkg/TestTextTokens2#args:[Ljava/lang/Object;
-(9:16, 9:19) method [declaration] pkg/TestTextTokens2#foo()V
-(10:7, 10:13) class [reference] java/lang/System
-(10:14, 10:17) field [reference] java/lang/System#out:Ljava/io/PrintStream;
-(10:18, 10:25) method [reference] java/io/PrintStream#println(Ljava/lang/String;)V
-(10:31, 10:35) field [reference] pkg/TestTextTokens2#name:Ljava/lang/String;
-(10:50, 10:55) field [reference] pkg/TestTextTokens2#value:Ljava/lang/Object;
-(13:16, 13:19) method [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V
-(13:20, 13:28) class [reference] java/util/function/Supplier
-(13:29, 13:37) class [reference] java/util/Optional
-(13:48, 13:58) class [reference] java/util/function/BiConsumer
-(13:61, 13:67) class [reference] java/lang/String
-(13:72, 13:73) parameter [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V(1:r)
-(14:7, 14:13) class [reference] java/lang/String
-(14:14, 14:15) local [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V(2:s)
-(15:9, 15:17) class [reference] java/util/Optional
-(15:18, 15:19) parameter [reference] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V(1:r)
-(15:20, 15:23) method [reference] java/util/function/Supplier#get()Ljava/lang/Object;
-(15:27, 15:36) method [reference] java/util/Optional#ifPresent(Ljava/util/function/Consumer;)V
-(15:37, 15:38) parameter [declaration] pkg/TestTextTokens2#lambda$bar$0(Ljava/lang/String;Ljava/util/function/BiConsumer;)V(2:c)
-(15:42, 15:43) parameter [reference] pkg/TestTextTokens2#lambda$bar$0(Ljava/lang/String;Ljava/util/function/BiConsumer;)V(2:c)
-(15:44, 15:50) method [reference] java/util/function/BiConsumer#accept(Ljava/lang/Object;Ljava/lang/Object;)V
-(15:56, 15:61) field [reference] pkg/TestTextTokens2#value:Ljava/lang/Object;
-(15:63, 15:64) local [reference] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V(2:s)
+(9:15, 9:30) class [declaration] pkg/TestTextTokens2
+(9:34, 9:40) class [reference] java/lang/String
+(9:41, 9:45) field [declaration] pkg/TestTextTokens2#name:Ljava/lang/String;
+(9:48, 9:65) class [reference] ext/ExampleAnnotation
+(9:68, 9:73) field [declaration] pkg/TestTextTokens2#value:Ljava/lang/Object;
+(9:79, 9:84) field [declaration] pkg/TestTextTokens2#index:I
+(9:86, 9:92) class [reference] java/lang/Object
+(9:96, 9:100) field [declaration] pkg/TestTextTokens2#args:[Ljava/lang/Object;
+(10:16, 10:19) method [declaration] pkg/TestTextTokens2#foo()V
+(11:7, 11:13) class [reference] java/lang/System
+(11:14, 11:17) field [reference] java/lang/System#out:Ljava/io/PrintStream;
+(11:18, 11:25) method [reference] java/io/PrintStream#println(Ljava/lang/String;)V
+(11:31, 11:35) field [reference] pkg/TestTextTokens2#name:Ljava/lang/String;
+(11:50, 11:55) field [reference] pkg/TestTextTokens2#value:Ljava/lang/Object;
+(14:16, 14:19) method [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V
+(14:20, 14:28) class [reference] java/util/function/Supplier
+(14:29, 14:37) class [reference] java/util/Optional
+(14:48, 14:58) class [reference] java/util/function/BiConsumer
+(14:62, 14:68) class [reference] java/lang/String
+(14:72, 14:73) parameter [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V(1:r)
+(15:7, 15:13) class [reference] java/lang/String
+(15:14, 15:15) local [declaration] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V(2:s)
+(16:9, 16:17) class [reference] java/util/Optional
+(16:18, 16:19) parameter [reference] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V(1:r)
+(16:20, 16:23) method [reference] java/util/function/Supplier#get()Ljava/lang/Object;
+(16:27, 16:36) method [reference] java/util/Optional#ifPresent(Ljava/util/function/Consumer;)V
+(16:37, 16:38) parameter [declaration] pkg/TestTextTokens2#lambda$bar$0(Ljava/lang/String;Ljava/util/function/BiConsumer;)V(2:c)
+(16:42, 16:43) parameter [reference] pkg/TestTextTokens2#lambda$bar$0(Ljava/lang/String;Ljava/util/function/BiConsumer;)V(2:c)
+(16:44, 16:50) method [reference] java/util/function/BiConsumer#accept(Ljava/lang/Object;Ljava/lang/Object;)V
+(16:56, 16:61) field [reference] pkg/TestTextTokens2#value:Ljava/lang/Object;
+(16:63, 16:64) local [reference] pkg/TestTextTokens2#bar(Ljava/util/function/Supplier;)V(2:s)
+(19:11, 19:19) class [reference] java/util/function/Function
+(19:20, 19:26) class [reference] java/lang/String
+(19:28, 19:34) class [reference] java/lang/String
+(19:36, 19:39) method [declaration] pkg/TestTextTokens2#baz()Ljava/util/function/Function;
+(20:14, 20:15) parameter [declaration] pkg/TestTextTokens2#lambda$baz$1(Ljava/lang/String;)Ljava/lang/String;(1:s)
+(20:19, 20:20) parameter [reference] pkg/TestTextTokens2#lambda$baz$1(Ljava/lang/String;)Ljava/lang/String;(1:s)
+(20:34, 20:38) field [reference] pkg/TestTextTokens2#name:Ljava/lang/String;
 */

--- a/testData/src/java16/pkg/TestTextTokens2.java
+++ b/testData/src/java16/pkg/TestTextTokens2.java
@@ -4,6 +4,7 @@ import ext.ExampleAnnotation;
 
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public record TestTextTokens2<T>(String name, @ExampleAnnotation T value, int index, Object... args) {
@@ -14,5 +15,9 @@ public record TestTextTokens2<T>(String name, @ExampleAnnotation T value, int in
   public void bar(Supplier<Optional<? extends BiConsumer<T, String>>> r) {
     String s = "Hello world";
     r.get().ifPresent(c -> c.accept(value, s));
+  }
+
+  public Function<String, String> baz() {
+    return s -> s + " " + this.name;
   }
 }


### PR DESCRIPTION
this fix is needed for enigma, since I want to make Quiltflower the default decompiler and this was the last issue to track down first. I also considered moving line 196 out of its else block as a fix, but that seems like it would just be a slower way to accomplish the same thing from a quick look.

fixes https://github.com/QuiltMC/enigma/issues/47, which was causing some generics to explode and look like this:
![image](https://user-images.githubusercontent.com/66223394/218222943-09ef9bec-c278-4e81-a026-b58cfa4d669e.png)

all credit for tracking this down goes to my brilliant friend @orifu :)