### PR TITLE
Delegate semicolons to plugins when possible

### DIFF
--- a/plugins/kotlin/src/main/java/org/vineflower/kotlin/KotlinChooser.java
+++ b/plugins/kotlin/src/main/java/org/vineflower/kotlin/KotlinChooser.java
@@ -43,6 +43,8 @@ public class KotlinChooser implements LanguageChooser {
         StructAnnotationAttribute attr = cl.getAttribute((Key<StructAnnotationAttribute>) key);
         for (AnnotationExprent anno : attr.getAnnotations()) {
           if (anno.getClassName().equals("kotlin/Metadata")) {
+            // Line removed as it slows down decompilation significantly, and it doesn't seem to break anything
+            //TODO double-check if it breaks anything
 //            setContextVariables(cl);
             return true;
           }

--- a/plugins/kotlin/src/main/java/org/vineflower/kotlin/KotlinChooser.java
+++ b/plugins/kotlin/src/main/java/org/vineflower/kotlin/KotlinChooser.java
@@ -43,7 +43,7 @@ public class KotlinChooser implements LanguageChooser {
         StructAnnotationAttribute attr = cl.getAttribute((Key<StructAnnotationAttribute>) key);
         for (AnnotationExprent anno : attr.getAnnotations()) {
           if (anno.getClassName().equals("kotlin/Metadata")) {
-            setContextVariables(cl);
+//            setContextVariables(cl);
             return true;
           }
         }

--- a/plugins/kotlin/src/main/java/org/vineflower/kotlin/KotlinWriter.java
+++ b/plugins/kotlin/src/main/java/org/vineflower/kotlin/KotlinWriter.java
@@ -92,6 +92,11 @@ public class KotlinWriter implements StatementWriter {
     javadocProvider = (IFabricJavadocProvider) DecompilerContext.getProperty(IFabricJavadocProvider.PROPERTY_NAME);
   }
 
+  @Override
+  public boolean endsWithSemicolon(Exprent expr) {
+    return false;
+  }
+
   private boolean invokeProcessors(TextBuffer buffer, ClassNode node) {
     ClassWrapper wrapper = node.getWrapper();
     if (wrapper == null) {

--- a/plugins/kotlin/testData/results/pkg/TestAnyType.dec
+++ b/plugins/kotlin/testData/results/pkg/TestAnyType.dec
@@ -3,10 +3,10 @@ package pkg
 public class TestAnyType {
    public fun test(param: Any): Int {
       if (param is java.lang.String) {// 5
-         return (param as java.lang.String).length();// 6
+         return (param as java.lang.String).length()// 6
       } else {
-         System.out.println(param);// 9
-         return 0;// 11
+         System.out.println(param)// 9
+         return 0// 11
       }
    }
 }

--- a/plugins/kotlin/testData/results/pkg/TestBitwiseFunctions.dec
+++ b/plugins/kotlin/testData/results/pkg/TestBitwiseFunctions.dec
@@ -2,27 +2,27 @@ package pkg
 
 public class TestBitwiseFunctions {
    public fun and(a: Int, b: Int): Int {
-      return a and b;// 5
+      return a and b// 5
    }
 
    public fun or(a: Int, b: Int): Int {
-      return a or b;// 9
+      return a or b// 9
    }
 
    public fun xor(a: Int, b: Int): Int {
-      return a xor b;// 13
+      return a xor b// 13
    }
 
    public fun shl(a: Int, b: Int): Int {
-      return a shl b;// 17
+      return a shl b// 17
    }
 
    public fun shr(a: Int, b: Int): Int {
-      return a shr b;// 21
+      return a shr b// 21
    }
 
    public fun ushr(a: Int, b: Int): Int {
-      return a ushr b;// 25
+      return a ushr b// 25
    }
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestClassDec.dec
+++ b/plugins/kotlin/testData/results/pkg/TestClassDec.dec
@@ -2,15 +2,15 @@ package pkg
 
 public class TestClassDec {
    public fun pkg.TestClassDec.Vec2iVal.dot(v: pkg.TestClassDec.Vec2iVal): Int {
-      return `$this$dot`.getX() * v.getX() + `$this$dot`.getY() * v.getY();// 11
+      return `$this$dot`.getX() * v.getX() + `$this$dot`.getY() * v.getY()// 11
    }
 
    public fun test() {
-      new TestClassDec.EmptyDec();
-      val vec: TestClassDec.Vec2iVal = new TestClassDec.Vec2iVal(1, 2);// 16
-      val vec1: TestClassDec.Vec2iVal = new TestClassDec.Vec2iVal(2, 4);// 17
-      System.out.println(vec.getX());// 19
-      System.out.println(this.dot(vec, vec1));// 20
+      new TestClassDec.EmptyDec()
+      val vec: TestClassDec.Vec2iVal = new TestClassDec.Vec2iVal(1, 2)// 16
+      val vec1: TestClassDec.Vec2iVal = new TestClassDec.Vec2iVal(2, 4)// 17
+      System.out.println(vec.getX())// 19
+      System.out.println(this.dot(vec, vec1))// 20
    }// 21
 
    public class EmptyDec
@@ -22,8 +22,8 @@ public class TestClassDec {
       public final val y: Int
 
       init {
-         this.x = x;// 7
-         this.y = y;
+         this.x = x// 7
+         this.y = y
       }
    }
 
@@ -35,8 +35,8 @@ public class TestClassDec {
          internal set
 
       init {
-         this.x = x;// 6
-         this.y = y;
+         this.x = x// 6
+         this.y = y
       }
    }
 }

--- a/plugins/kotlin/testData/results/pkg/TestClassicStringInterpolation.dec
+++ b/plugins/kotlin/testData/results/pkg/TestClassicStringInterpolation.dec
@@ -4,23 +4,23 @@ public class TestClassicStringInterpolation {
    public final val x: Int = 5// 16
 
    public fun stringInterpolation(x: Int, y: String) {
-      System.out.println("$x $y");// 5
+      System.out.println("$x $y")// 5
    }// 6
 
    public fun testConstant(x: Int) {
-      System.out.println("$x 5");// 9
+      System.out.println("$x 5")// 9
    }// 10
 
    public fun testExpression(x: Int) {
-      System.out.println("$x ${x + 1}");// 13
+      System.out.println("$x ${x + 1}")// 13
    }// 14
 
    public fun testProperty() {
-      System.out.println("${this.x}!");// 18
+      System.out.println("${this.x}!")// 18
    }// 19
 
    public fun testLiteralClass() {
-      System.out.println("${TestClassicStringInterpolation::class.java}!");// 22
+      System.out.println("${TestClassicStringInterpolation::class.java}!")// 22
    }// 23
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestCompanionObject.dec
+++ b/plugins/kotlin/testData/results/pkg/TestCompanionObject.dec
@@ -2,19 +2,19 @@ package pkg
 
 public class TestCompanionObject {
    public fun notInCompanion() {
-      System.out.println("notInCompanion");// 5
+      System.out.println("notInCompanion")// 5
    }// 6
 
    @JvmStatic
    @JvmSynthetic
    fun `access$getCompanionVal$cp`(): java.lang.String {
-      return companionVal;
+      return companionVal
    }
 
    @JvmStatic
    @JvmSynthetic
    fun `access$getCompanionValJvmStatic$cp`(): java.lang.String {
-      return companionValJvmStatic;// 3
+      return companionValJvmStatic// 3
    }
 
    public companion object {
@@ -24,11 +24,11 @@ public class TestCompanionObject {
       public final val companionValJvmStatic: String
 
       public fun inCompanion() {
-         System.out.println("inCompanion");// 15
+         System.out.println("inCompanion")// 15
       }// 16
 
       public fun inCompanionJvmStatic() {
-         System.out.println("inCompanionJvmStatic");// 20
+         System.out.println("inCompanionJvmStatic")// 20
       }// 21
    }
 }

--- a/plugins/kotlin/testData/results/pkg/TestComparison.dec
+++ b/plugins/kotlin/testData/results/pkg/TestComparison.dec
@@ -2,27 +2,27 @@ package pkg
 
 public class TestComparison {
    public fun test2(a: Any, b: Any): Boolean {
-      return a == b;// 5
+      return a == b// 5
    }
 
    public fun test3(a: Any, b: Any): Boolean {
-      return a === b;// 9
+      return a === b// 9
    }
 
    public fun testNull2(a: Any?): Boolean {
-      return a == null;// 13
+      return a == null// 13
    }
 
    public fun testNull3(a: Any?): Boolean {
-      return a == null;// 17
+      return a == null// 17
    }
 
    public fun testNullDouble2(a: Any?, b: Any?): Boolean {
-      return a == b;// 21
+      return a == b// 21
    }
 
    public fun testNullDouble3(a: Any?, b: Any?): Boolean {
-      return a === b;// 25
+      return a === b// 25
    }
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestCompileTimeErrors.dec
+++ b/plugins/kotlin/testData/results/pkg/TestCompileTimeErrors.dec
@@ -2,7 +2,7 @@ package pkg
 
 public class TestCompileTimeErrors {
    public fun <I, O> test(i: I): O where O : I, O : pkg.TestCompileTimeErrors.Test {
-      throw new NotImplementedError(null, 1, null);// 10
+      throw new NotImplementedError(null, 1, null)// 10
    }
 
    public fun test2(i: Int?): pkg.TestCompileTimeErrors.Test? {
@@ -10,18 +10,18 @@ public class TestCompileTimeErrors {
          private final Integer testValue;
 
          {
-            this.testValue = `$i`;// 16
+            this.testValue = `$i`// 16
          }// 14
 
          public Integer getTestValue() {
-            return this.testValue;// 15
+            return this.testValue// 15
          }
 
          /** @deprecated */
          // $VF: synthetic method
          public static void getTestValue$annotations() {
          }
-      };
+      }
    }
 
    public interface Test {

--- a/plugins/kotlin/testData/results/pkg/TestConstructors.dec
+++ b/plugins/kotlin/testData/results/pkg/TestConstructors.dec
@@ -2,11 +2,11 @@ package pkg
 
 public class TestConstructors private constructor() {
    public constructor(a: Int) : this() {// 4
-      System.out.println("a = $a");// 5
+      System.out.println("a = $a")// 5
    }// 6
 
    public constructor(a: Int, b: Int) : this(a) {// 8
-      System.out.println("b = $b");// 9
+      System.out.println("b = $b")// 9
    }// 10
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestContracts.dec
+++ b/plugins/kotlin/testData/results/pkg/TestContracts.dec
@@ -11,9 +11,9 @@ public class TestContracts {
       }
 
       if (x == null) {// 13
-         throw new IllegalStateException("x is null".toString());
+         throw new IllegalStateException("x is null".toString())
       } else {
-         return x;// 14
+         return x// 14
       }
    }
 
@@ -24,7 +24,7 @@ public class TestContracts {
          returns(false) implies ((a && !b || (!a && b)
       }
 
-      return if (a && b) null else a || b;// 24
+      return if (a && b) null else a || b// 24
    }
 
    public fun testTypeContract(x: Any?): Int {
@@ -33,9 +33,9 @@ public class TestContracts {
       }
 
       if (x !is Int) {// 31
-         throw new IllegalStateException("x is not Int".toString());
+         throw new IllegalStateException("x is not Int".toString())
       } else {
-         return (x as java.lang.Number).intValue();// 32
+         return (x as java.lang.Number).intValue()// 32
       }
    }
 
@@ -44,7 +44,7 @@ public class TestContracts {
          callsInPlace(f, InvocationKind.EXACTLY_ONCE)
       }
 
-      return (f.invoke() as java.lang.Number).intValue();// 39
+      return (f.invoke() as java.lang.Number).intValue()// 39
    }
 
    public fun testFunctionalContract2(f: () -> Int, b: Boolean): Int {
@@ -52,7 +52,7 @@ public class TestContracts {
          callsInPlace(f, InvocationKind.AT_MOST_ONCE)
       }
 
-      return if (b) (f.invoke() as java.lang.Number).intValue() else 0;// 46
+      return if (b) (f.invoke() as java.lang.Number).intValue() else 0// 46
    }
 
    public fun testFunctionalContract3(f: () -> Int, i: Int): Int {
@@ -60,16 +60,16 @@ public class TestContracts {
          callsInPlace(f)
       }
 
-      val var3: java.lang.Iterable = (new IntRange(0, i)) as java.lang.Iterable;
-      var var4: Int = 0;
-      val var5: java.util.Iterator = var3.iterator();
+      val var3: java.lang.Iterable = (new IntRange(0, i)) as java.lang.Iterable
+      var var4: Int = 0
+      val var5: java.util.Iterator = var3.iterator()
 
       while (var5.hasNext()) {
-         val var6: Int = (var5 as IntIterator).nextInt();
-         var4 += (f.invoke() as java.lang.Number).intValue();
+         val var6: Int = (var5 as IntIterator).nextInt()
+         var4 += (f.invoke() as java.lang.Number).intValue()
       }
 
-      return var4;// 53
+      return var4// 53
    }
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestConvertedK2JOps.dec
+++ b/plugins/kotlin/testData/results/pkg/TestConvertedK2JOps.dec
@@ -7,7 +7,7 @@ public class TestConvertedK2JOps {
    public final val any: Any = new Object()
 
    public fun codeConstructs() {
-      System.out.println("Hello, world!");// 10
+      System.out.println("Hello, world!")// 10
    }// 12
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestDataClass.dec
+++ b/plugins/kotlin/testData/results/pkg/TestDataClass.dec
@@ -7,26 +7,26 @@ public data class TestDataClass(dataClassVal: Regex, variableWithVeryLongName: I
    public final val nullability: String?
 
    init {
-      this.dataClassVal = dataClassVal;// 4
-      this.variableWithVeryLongName = variableWithVeryLongName;// 5
-      this.requestLineWrapsIfTheParamListIsTooLong = requestLineWrapsIfTheParamListIsTooLong;// 6
-      this.nullability = nullability;// 7
+      this.dataClassVal = dataClassVal// 4
+      this.variableWithVeryLongName = variableWithVeryLongName// 5
+      this.requestLineWrapsIfTheParamListIsTooLong = requestLineWrapsIfTheParamListIsTooLong// 6
+      this.nullability = nullability// 7
    }// 3
 
    public operator fun component1(): Regex {
-      return this.dataClassVal;
+      return this.dataClassVal
    }
 
    public operator fun component2(): Int {
-      return this.variableWithVeryLongName;
+      return this.variableWithVeryLongName
    }
 
    public operator fun component3(): List<String> {
-      return this.requestLineWrapsIfTheParamListIsTooLong;
+      return this.requestLineWrapsIfTheParamListIsTooLong
    }
 
    public operator fun component4(): String? {
-      return this.nullability;
+      return this.nullability
    }
 
    public fun copy(
@@ -35,11 +35,11 @@ public data class TestDataClass(dataClassVal: Regex, variableWithVeryLongName: I
       requestLineWrapsIfTheParamListIsTooLong: List<String> = this.requestLineWrapsIfTheParamListIsTooLong,
       nullability: String? = this.nullability
    ): TestDataClass {
-      return new TestDataClass(dataClassVal, variableWithVeryLongName, requestLineWrapsIfTheParamListIsTooLong, nullability);
+      return new TestDataClass(dataClassVal, variableWithVeryLongName, requestLineWrapsIfTheParamListIsTooLong, nullability)
    }
 
    public open fun toString(): String {
-      return "TestDataClass(dataClassVal=${this.dataClassVal}, variableWithVeryLongName=${this.variableWithVeryLongName}, requestLineWrapsIfTheParamListIsTooLong=${this.requestLineWrapsIfTheParamListIsTooLong}, nullability=${this.nullability})";
+      return "TestDataClass(dataClassVal=${this.dataClassVal}, variableWithVeryLongName=${this.variableWithVeryLongName}, requestLineWrapsIfTheParamListIsTooLong=${this.requestLineWrapsIfTheParamListIsTooLong}, nullability=${this.nullability})"
    }
 
    public open fun hashCode(): Int {
@@ -48,24 +48,24 @@ public data class TestDataClass(dataClassVal: Regex, variableWithVeryLongName: I
                   + this.requestLineWrapsIfTheParamListIsTooLong.hashCode()
             )
             * 31
-         + (if (this.nullability == null) 0 else this.nullability.hashCode());
-   }
+         + (if (this.nullability == null) 0 else this.nullability.hashCode())
+      }
 
    public open operator fun equals(other: Any?): Boolean {
       if (this === other) {
-         return true;
+         return true
       } else if (other !is TestDataClass) {
-         return false;
+         return false
       } else {
-         val var2: TestDataClass = other as TestDataClass;
+         val var2: TestDataClass = other as TestDataClass
          if (!(this.dataClassVal == (other as TestDataClass).dataClassVal)) {
-            return false;
+            return false
          } else if (this.variableWithVeryLongName != var2.variableWithVeryLongName) {
-            return false;
+            return false
          } else if (!(this.requestLineWrapsIfTheParamListIsTooLong == var2.requestLineWrapsIfTheParamListIsTooLong)) {
-            return false;
+            return false
          } else {
-            return this.nullability == var2.nullability;
+            return this.nullability == var2.nullability
          }
       }
    }

--- a/plugins/kotlin/testData/results/pkg/TestDestructors.dec
+++ b/plugins/kotlin/testData/results/pkg/TestDestructors.dec
@@ -6,31 +6,31 @@ import kotlin.jvm.internal.SourceDebugExtension
 @SourceDebugExtension(["SMAP\nTestDestructors.kt\nKotlin\n*S Kotlin\n*F\n+ 1 TestDestructors.kt\npkg/TestDestructors\n*L\n1#1,71:1\n68#1,3:72\n68#1,3:75\n*S KotlinDebug\n*F\n+ 1 TestDestructors.kt\npkg/TestDestructors\n*L\n49#1:72,3\n54#1:75,3\n*E\n"])
 public class TestDestructors {
    public fun destructDataClasses(x: Pair<String, Int?>, y: Triple<Number, Boolean?, String>) {
-      System.out.println("${x.component1() as java.lang.String} ${x.component2() as Int}");// 8 9
-      System.out.println("${y.component1() as java.lang.Number} ${y.component2() as java.lang.Boolean} ${y.component3() as java.lang.String}");// 11 12
+      System.out.println("${x.component1() as java.lang.String} ${x.component2() as Int}")// 8 9
+      System.out.println("${y.component1() as java.lang.Number} ${y.component2() as java.lang.Boolean} ${y.component3() as java.lang.String}")// 11 12
    }// 13
 
    public fun destructDataClassesSpecial(x: Pair<Int, String>, y: Triple<List<Int>, Nothing?, Unit>) {
-      System.out.println("${(x.component1() as java.lang.Number).intValue()} ${x.component2() as java.lang.String}");// 19 20
-      val c: java.util.List = y.component1() as java.util.List;// 22
-      val d: Void = y.component2() as Void;
-      y.component3();
-      System.out.println("$c $d ${Unit.INSTANCE}");// 23
+      System.out.println("${(x.component1() as java.lang.Number).intValue()} ${x.component2() as java.lang.String}")// 19 20
+      val c: java.util.List = y.component1() as java.util.List// 22
+      val d: Void = y.component2() as Void
+      y.component3()
+      System.out.println("$c $d ${Unit.INSTANCE}")// 23
    }// 24
 
    public fun destructDataClassesSkip(x: Triple<String, Int?, String>, y: Triple<Number, Boolean?, String>) {
-      System.out.println(x.component2() as Int);// 30 31
-      System.out.println("${y.component1() as java.lang.Number} ${y.component3() as java.lang.String}");// 33 34
+      System.out.println(x.component2() as Int)// 30 31
+      System.out.println("${y.component1() as java.lang.Number} ${y.component3() as java.lang.String}")// 33 34
    }// 35
 
    public fun destructorImpossible(x: Pair<String, Nothing>): String {
-      val a: java.lang.String = x.component1() as java.lang.String;// 38
-      x.component2();
-      throw new KotlinNothingValueException();
+      val a: java.lang.String = x.component1() as java.lang.String// 38
+      x.component2()
+      throw new KotlinNothingValueException()
    }
 
    public fun destructExtensionFunction(x: Int) {
-      System.out.println("${this.component1(x)}${this.component2(x)}${this.component3(x)}");// 44 45
+      System.out.println("${this.component1(x)}${this.component2(x)}${this.component3(x)}")// 44 45
    }// 46
 
    public fun destructInlineLambdaNoInline(x: () -> Int) {
@@ -39,46 +39,46 @@ public class TestDestructors {
             "${this.component1((x.invoke() as java.lang.Number).intValue())}${this.component2((x.invoke() as java.lang.Number).intValue())}${this.component3(// 49 50 72 73 74
                (x.invoke() as java.lang.Number).intValue()
             )}"
-         );
-   }// 51
+         )
+      }// 51
 
    public fun destructLambdaInline(x: Int) {
-      val var2: Function0 = TestDestructors::destructLambdaInline$lambda$0;
+      val var2: Function0 = TestDestructors::destructLambdaInline$lambda$0
       System.out
          .println(
             "${this.component1((var2.invoke() as java.lang.Number).intValue())}${this.component2((var2.invoke() as java.lang.Number).intValue())}${this.component3(// 55 75 76 77
                (var2.invoke() as java.lang.Number).intValue()
             )}"
-         );
-   }// 56
+         )
+      }// 56
 
    public operator fun Int.component1(): Int {
-      return java.lang.String.valueOf(`$this$component1`).charAt(0) - 48;// 64
+      return java.lang.String.valueOf(`$this$component1`).charAt(0) - 48// 64
    }
 
    public operator fun Int.component2(): Int {
-      return java.lang.String.valueOf(`$this$component2`).charAt(1) - 48;// 65
+      return java.lang.String.valueOf(`$this$component2`).charAt(1) - 48// 65
    }
 
    public operator fun Int.component3(): Int {
-      return java.lang.String.valueOf(`$this$component3`).charAt(2) - 48;// 66
+      return java.lang.String.valueOf(`$this$component3`).charAt(2) - 48// 66
    }
 
    public inline operator fun (() -> Int).component1(): Int {
-      return this.component1((`$this$component1`.invoke() as java.lang.Number).intValue());// 68
+      return this.component1((`$this$component1`.invoke() as java.lang.Number).intValue())// 68
    }
 
    public inline operator fun (() -> Int).component2(): Int {
-      return this.component2((`$this$component2`.invoke() as java.lang.Number).intValue());// 69
+      return this.component2((`$this$component2`.invoke() as java.lang.Number).intValue())// 69
    }
 
    public inline operator fun (() -> Int).component3(): Int {
-      return this.component3((`$this$component3`.invoke() as java.lang.Number).intValue());// 70
+      return this.component3((`$this$component3`.invoke() as java.lang.Number).intValue())// 70
    }
 
    @JvmStatic
    fun `destructLambdaInline$lambda$0`(`$x`: Int): Int {
-      return `$x`;// 54
+      return `$x`// 54
    }
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestEnumClass.dec
+++ b/plugins/kotlin/testData/results/pkg/TestEnumClass.dec
@@ -11,22 +11,22 @@ public enum class TestEnumClass(number: Int = 4) {
    public final val number: Int
 
    init {
-      this.number = number;// 3
+      this.number = number// 3
    }
 
    public fun foo(): Int {
-      return this.number;// 7
+      return this.number// 7
    }
 
    @JvmStatic
    fun getEntries(): EnumEntries<TestEnumClass> {
-      return $ENTRIES;// 8
+      return $ENTRIES// 8
    }
 
    @JvmStatic
    @JvmSynthetic
    fun `$values`(): Array<TestEnumClass> {
-      return new TestEnumClass[]{A, B, C, D};
+      return new TestEnumClass[]{A, B, C, D}
    }
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestExtensionFun.dec
+++ b/plugins/kotlin/testData/results/pkg/TestExtensionFun.dec
@@ -2,11 +2,11 @@ package pkg
 
 public class TestExtensionFun {
    public fun CharSequence.repeat2(n: Int): String {
-      return StringsKt.repeat(`$this$repeat2`, n);// 5
+      return StringsKt.repeat(`$this$repeat2`, n)// 5
    }
 
    public fun test() {
-      System.out.println(this.repeat2("Bye " as java.lang.CharSequence, 2));// 9
+      System.out.println(this.repeat2("Bye " as java.lang.CharSequence, 2))// 9
    }// 10
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestForRange.dec
+++ b/plugins/kotlin/testData/results/pkg/TestForRange.dec
@@ -5,45 +5,45 @@ import kotlin.internal.ProgressionUtilKt
 public class TestForRange {
    public fun testInt() {
       for (i in 1..10) {// 5
-         System.out.println(i);// 6
+         System.out.println(i)// 6
       }
    }// 8
 
    public fun testChar() {
       for (c in 'a'..'z') {// 11
-         System.out.println(c);// 12
+         System.out.println(c)// 12
       }
    }// 14
 
    public fun testIntStep() {
-      var i: Int = 1;
-      val var2: Int = ProgressionUtilKt.getProgressionLastElement(1, 10, 2);
+      var i: Int = 1
+      val var2: Int = ProgressionUtilKt.getProgressionLastElement(1, 10, 2)
       if (1 <= var2) {
          while (true) {
-            System.out.println(i);// 18
+            System.out.println(i)// 18
             if (i == var2) {// 17
                break
             }
 
-            i += 2;
+            i += 2
          }
       }
    }// 20
 
    public fun testIntStepX(x: Int) {
       if (x <= 0) {
-         throw new IllegalArgumentException("Step must be positive, was: $x.");
+         throw new IllegalArgumentException("Step must be positive, was: $x.")
       } else {
-         var i: Int = 1;
-         val var3: Int = ProgressionUtilKt.getProgressionLastElement(1, 100, x);
+         var i: Int = 1
+         val var3: Int = ProgressionUtilKt.getProgressionLastElement(1, 100, x)
          if (1 <= var3) {
             while (true) {
-               System.out.println(i);// 24
+               System.out.println(i)// 24
                if (i == var3) {// 23
                   break
                }
 
-               i += x;
+               i += x
             }
          }
       }
@@ -51,40 +51,40 @@ public class TestForRange {
 
    public fun testIntDownTo() {
       for (i in 10 downTo 1) {// 29
-         System.out.println(i);// 30
+         System.out.println(i)// 30
       }
    }// 32
 
    public fun testIntDownToStep() {
-      var i: Int = 10;
-      val var2: Int = ProgressionUtilKt.getProgressionLastElement(10, 1, -2);
+      var i: Int = 10
+      val var2: Int = ProgressionUtilKt.getProgressionLastElement(10, 1, -2)
       if (var2 <= 10) {
          while (true) {
-            System.out.println(i);// 36
+            System.out.println(i)// 36
             if (i == var2) {// 35
                break
             }
 
-            i -= 2;
+            i -= 2
          }
       }
    }// 38
 
    public fun testIntDownToStepX(x: Int) {
       if (x <= 0) {
-         throw new IllegalArgumentException("Step must be positive, was: $x.");
+         throw new IllegalArgumentException("Step must be positive, was: $x.")
       } else {
-         val var2: Int = -x;
-         var i: Int = 100;
-         val var4: Int = ProgressionUtilKt.getProgressionLastElement(100, 1, var2);
+         val var2: Int = -x
+         var i: Int = 100
+         val var4: Int = ProgressionUtilKt.getProgressionLastElement(100, 1, var2)
          if (var4 <= 100) {
             while (true) {
-               System.out.println(i);// 42
+               System.out.println(i)// 42
                if (i == var4) {// 41
                   break
                }
 
-               i += var2;
+               i += var2
             }
          }
       }
@@ -92,87 +92,87 @@ public class TestForRange {
 
    public fun testUntil() {
       for (i in 1..9) {// 47
-         System.out.println(i);// 48
+         System.out.println(i)// 48
       }
    }// 50
 
    public fun testUntilStep() {
-      val var1: IntProgression = RangesKt.step(RangesKt.until(1, 100) as IntProgression, 2);
-      var i: Int = var1.getFirst();
-      val var3: Int = var1.getLast();
-      val var4: Int = var1.getStep();
+      val var1: IntProgression = RangesKt.step(RangesKt.until(1, 100) as IntProgression, 2)
+      var i: Int = var1.getFirst()
+      val var3: Int = var1.getLast()
+      val var4: Int = var1.getStep()
       if (var4 > 0 && i <= var3 || var4 < 0 && var3 <= i) {
          while (true) {
-            System.out.println(i);// 54
+            System.out.println(i)// 54
             if (i == var3) {// 53
                break
             }
 
-            i += var4;
+            i += var4
          }
       }
    }// 56
 
    public fun testUntilStepX(x: Int) {
-      val var2: IntProgression = RangesKt.step(RangesKt.until(1, 100) as IntProgression, x);
-      var i: Int = var2.getFirst();
-      val var4: Int = var2.getLast();
-      val var5: Int = var2.getStep();
+      val var2: IntProgression = RangesKt.step(RangesKt.until(1, 100) as IntProgression, x)
+      var i: Int = var2.getFirst()
+      val var4: Int = var2.getLast()
+      val var5: Int = var2.getStep()
       if (var5 > 0 && i <= var4 || var5 < 0 && var4 <= i) {
          while (true) {
-            System.out.println(i);// 60
+            System.out.println(i)// 60
             if (i == var4) {// 59
                break
             }
 
-            i += var5;
+            i += var5
          }
       }
    }// 62
 
    public fun testIntY(x: Int, y: Int) {
-      var i: Int = x;
+      var i: Int = x
       if (x <= y) {
          while (true) {
-            System.out.println(i);// 66
+            System.out.println(i)// 66
             if (i == y) {// 65
                break
             }
 
-            i++;
+            i++
          }
       }
    }// 68
 
    public fun testIntYStep(x: Int, y: Int) {
-      var i: Int = x;
-      val var4: Int = ProgressionUtilKt.getProgressionLastElement(x, y, 2);
+      var i: Int = x
+      val var4: Int = ProgressionUtilKt.getProgressionLastElement(x, y, 2)
       if (x <= var4) {
          while (true) {
-            System.out.println(i);// 72
+            System.out.println(i)// 72
             if (i == var4) {// 71
                break
             }
 
-            i += 2;
+            i += 2
          }
       }
    }// 74
 
    public fun testIntYStepX(x: Int, y: Int, z: Int) {
       if (z <= 0) {
-         throw new IllegalArgumentException("Step must be positive, was: $z.");
+         throw new IllegalArgumentException("Step must be positive, was: $z.")
       } else {
-         var i: Int = x;
-         val var5: Int = ProgressionUtilKt.getProgressionLastElement(x, y, z);
+         var i: Int = x
+         val var5: Int = ProgressionUtilKt.getProgressionLastElement(x, y, z)
          if (x <= var5) {
             while (true) {
-               System.out.println(i);// 78
+               System.out.println(i)// 78
                if (i == var5) {// 77
                   break
                }
 
-               i += z;
+               i += z
             }
          }
       }

--- a/plugins/kotlin/testData/results/pkg/TestFunVarargs.dec
+++ b/plugins/kotlin/testData/results/pkg/TestFunVarargs.dec
@@ -5,23 +5,23 @@ import java.util.Arrays
 public class TestFunVarargs {
    public fun printAll(vararg messages: String) {
       for (m in messages) {// 5
-         System.out.println(m);
+         System.out.println(m)
       }
    }// 6
 
    public fun printAllArray(messages: Array<out String>) {
       for (m in messages) {// 9
-         System.out.println(m);
+         System.out.println(m)
       }
    }// 10
 
    public fun log(vararg entries: String) {
-      this.printAll(Arrays.copyOf(entries, entries.length) as Array<java.lang.String>);// 13
-      this.printAllArray(entries);// 14
+      this.printAll(Arrays.copyOf(entries, entries.length) as Array<java.lang.String>)// 13
+      this.printAllArray(entries)// 14
    }// 15
 
    public fun test() {
-      this.log("a", "b", "c");// 18
+      this.log("a", "b", "c")// 18
    }// 19
 
    public fun nestedArrays(e0: Array<String>, e1: Array<in String>, e2: Array<Array<Array<String>>>) {

--- a/plugins/kotlin/testData/results/pkg/TestFuncRef.dec
+++ b/plugins/kotlin/testData/results/pkg/TestFuncRef.dec
@@ -1,15 +1,15 @@
 package pkg
 
 public fun accept(f: (Int) -> String) {
-   System.out.println(f.invoke(5));
+   System.out.println(f.invoke(5))
 }// 3
 
 public fun function(r: Int): String {
-   return StringsKt.repeat("OK" as java.lang.CharSequence, r);// 6
+   return StringsKt.repeat("OK" as java.lang.CharSequence, r)// 6
 }
 
 public fun test() {
-   accept(<unknownclass>.INSTANCE);// 10
+   accept(<unknownclass>.INSTANCE)// 10
 }// 11
 
 class 'pkg/TestFuncRefKt' {

--- a/plugins/kotlin/testData/results/pkg/TestGenerics.dec
+++ b/plugins/kotlin/testData/results/pkg/TestGenerics.dec
@@ -2,11 +2,11 @@ package pkg
 
 public class TestGenerics<T> {
    public fun <T> genericFun(v: T): T {
-      return (T)v;// 5
+      return (T)v// 5
    }
 
    public fun <T> nullableGeneric(v: T): T? {
-      return null;// 9
+      return null// 9
    }
 
    public fun <T> subType(v: TestGenerics<out T>) {

--- a/plugins/kotlin/testData/results/pkg/TestIfRange.dec
+++ b/plugins/kotlin/testData/results/pkg/TestIfRange.dec
@@ -3,73 +3,73 @@ package pkg
 public class TestIfRange {
    public fun testInt(x: Int) {
       if (1 <= x && x < 11) {// 5
-         System.out.println(x);// 6
+         System.out.println(x)// 6
       }
    }// 8
 
    public fun testChar(x: Char) {
       if ('a' <= x && x < '{') {// 11
-         System.out.println(x);// 12
+         System.out.println(x)// 12
       }
    }// 14
 
    public fun testInvertedInt(x: Int) {
       if (1 > x || x >= 11) {// 17
-         System.out.println(x);// 18
+         System.out.println(x)// 18
       }
    }// 20
 
    public fun testIntStep(x: Int) {
       if (CollectionsKt.contains(RangesKt.step((new IntRange(1, 100)) as IntProgression, 2) as java.lang.Iterable, x)) {// 23
-         System.out.println(x);// 24
+         System.out.println(x)// 24
       }
    }// 26
 
    public fun testIntStepY(x: Int, y: Int) {
       if (CollectionsKt.contains(RangesKt.step((new IntRange(1, 100)) as IntProgression, y) as java.lang.Iterable, x)) {// 28
-         System.out.println(x);// 29
+         System.out.println(x)// 29
       }
    }// 31
 
    public fun testIntY(x: Int, y: Int) {
       if (1 <= x && x <= y) {// 34
-         System.out.println(x);// 35
+         System.out.println(x)// 35
       }
    }// 37
 
    public fun testIntDownTo(x: Int) {
       if (CollectionsKt.contains(RangesKt.downTo(10, 1) as java.lang.Iterable, x)) {// 40
-         System.out.println(x);// 41
+         System.out.println(x)// 41
       }
    }// 43
 
    public fun testIntDownToStep(x: Int) {
       if (CollectionsKt.contains(RangesKt.step(RangesKt.downTo(10, 1), 2) as java.lang.Iterable, x)) {// 46
-         System.out.println(x);// 47
+         System.out.println(x)// 47
       }
    }// 49
 
    public fun testIntUntil(x: Int) {
       if (1 <= x && x < 10) {// 52
-         System.out.println(x);// 53
+         System.out.println(x)// 53
       }
    }// 55
 
    public fun testIntUntilStep(x: Int) {
       if (CollectionsKt.contains(RangesKt.step(RangesKt.until(1, 100) as IntProgression, 2) as java.lang.Iterable, x)) {// 58
-         System.out.println(x);// 59
+         System.out.println(x)// 59
       }
    }// 61
 
    public fun testIntUntilY(x: Int, y: Int) {
       if (1 <= x && x < y) {// 64
-         System.out.println(x);// 65
+         System.out.println(x)// 65
       }
    }// 67
 
    public fun testIntUntilSelf(x: Int) {
       if (1 <= x && x < x) {// 70
-         System.out.println(x);// 71
+         System.out.println(x)// 71
       }
    }// 73
 }

--- a/plugins/kotlin/testData/results/pkg/TestInfixFun.dec
+++ b/plugins/kotlin/testData/results/pkg/TestInfixFun.dec
@@ -2,29 +2,29 @@ package pkg
 
 public class TestInfixFun {
    public fun test() {
-      System.out.println(test$times(2, "Bye "));// 7
+      System.out.println(test$times(2, "Bye "))// 7
    }// 8
 
    public infix fun Int.mult(str: String): String {
-      return StringsKt.repeat(str as java.lang.CharSequence, `$this$mult`);// 10
+      return StringsKt.repeat(str as java.lang.CharSequence, `$this$mult`)// 10
    }
 
    public fun testOuter() {
-      System.out.println(this.mult(2, "Bye "));// 14
+      System.out.println(this.mult(2, "Bye "))// 14
    }// 15
 
    public fun testDuplicate() {
-      System.out.println(testDuplicate$mult(2, "Bye "));// 20
+      System.out.println(testDuplicate$mult(2, "Bye "))// 20
    }// 21
 
    @JvmStatic
    fun Int.`test$times`(str: java.lang.String): java.lang.String {
-      return StringsKt.repeat(str as java.lang.CharSequence, `$this$test_u24times`);// 5
+      return StringsKt.repeat(str as java.lang.CharSequence, `$this$test_u24times`)// 5
    }
 
    @JvmStatic
    fun Int.`testDuplicate$mult`(str: java.lang.String): java.lang.String {
-      return StringsKt.repeat(str as java.lang.CharSequence, `$this$testDuplicate_u24mult` + 1);// 18
+      return StringsKt.repeat(str as java.lang.CharSequence, `$this$testDuplicate_u24mult` + 1)// 18
    }
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestKotlinTypes.dec
+++ b/plugins/kotlin/testData/results/pkg/TestKotlinTypes.dec
@@ -4,12 +4,12 @@ public class TestKotlinTypes {
    public final val consumer: (Int) -> Unit = TestKotlinTypes::consumer$lambda$0
 
    public fun throwAlways(): Nothing {
-      throw new Exception();// 5
+      throw new Exception()// 5
    }
 
    @JvmStatic
    fun `consumer$lambda$0`(it: Int): Unit {
-      return Unit.INSTANCE;// 8
+      return Unit.INSTANCE// 8
    }
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestKt.dec
+++ b/plugins/kotlin/testData/results/pkg/TestKt.dec
@@ -2,7 +2,7 @@ package pkg
 
 public class TestKt {
    public fun test() {
-      System.out.println("Hello, world!");// 5
+      System.out.println("Hello, world!")// 5
    }// 6
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestLabeledJumps.dec
+++ b/plugins/kotlin/testData/results/pkg/TestLabeledJumps.dec
@@ -8,10 +8,10 @@ public class TestLabeledJumps {
                continue@label36
             }
 
-            System.out.println("$j $i");// 11
+            System.out.println("$j $i")// 11
          }
 
-         System.out.println("loop");// 14
+         System.out.println("loop")// 14
       }
    }// 16
 
@@ -22,11 +22,11 @@ public class TestLabeledJumps {
                break@label33
             }
 
-            System.out.println("$j $i");// 25
+            System.out.println("$j $i")// 25
          }
       }
 
-      System.out.println("end");// 29
+      System.out.println("end")// 29
    }// 30
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestNonInlineLambda.dec
+++ b/plugins/kotlin/testData/results/pkg/TestNonInlineLambda.dec
@@ -14,84 +14,84 @@ public open class TestNonInlineLambda {
    private final var privateStringField: String = ""// 132
 
    public fun testCaptureInt(x: Int) {
-      this.execute(TestNonInlineLambda::testCaptureInt$lambda$0);// 8
+      this.execute(TestNonInlineLambda::testCaptureInt$lambda$0)// 8
    }// 11
 
    public fun testCaptureObject(x: String) {
-      this.execute(TestNonInlineLambda::testCaptureObject$lambda$1);// 15
+      this.execute(TestNonInlineLambda::testCaptureObject$lambda$1)// 15
    }// 18
 
    public fun testCaptureIntIterationValue(x: Iterable<Int>) {
-      val var2: java.util.Iterator = x.iterator();// 21
+      val var2: java.util.Iterator = x.iterator()// 21
 
       while (var2.hasNext()) {
-         this.execute(TestNonInlineLambda::testCaptureIntIterationValue$lambda$2);// 22
+         this.execute(TestNonInlineLambda::testCaptureIntIterationValue$lambda$2)// 22
       }
    }// 26
 
    public fun testCaptureObjectIterationValue(x: Iterable<String>) {
       for (i in x) {// 29
-         this.execute(TestNonInlineLambda::testCaptureObjectIterationValue$lambda$3);// 30
+         this.execute(TestNonInlineLambda::testCaptureObjectIterationValue$lambda$3)// 30
       }
    }// 34
 
    public fun testCaptureMutableInt(x: Int) {
-      val y: IntRef = new IntRef();// 37
-      y.element = x;
-      this.execute(TestNonInlineLambda::testCaptureMutableInt$lambda$4);// 38
-      val var3: Int = y.element++;// 41
-      this.execute(TestNonInlineLambda::testCaptureMutableInt$lambda$5);// 42
-      y.element *= 500;// 45
-      this.execute(TestNonInlineLambda::testCaptureMutableInt$lambda$6);// 46
-      y.element = 100;// 49
-      this.execute(TestNonInlineLambda::testCaptureMutableInt$lambda$7);// 50
-      y.element += x;// 53
-      this.execute(TestNonInlineLambda::testCaptureMutableInt$lambda$8);// 54
+      val y: IntRef = new IntRef()// 37
+      y.element = x
+      this.execute(TestNonInlineLambda::testCaptureMutableInt$lambda$4)// 38
+      val var3: Int = y.element++// 41
+      this.execute(TestNonInlineLambda::testCaptureMutableInt$lambda$5)// 42
+      y.element *= 500// 45
+      this.execute(TestNonInlineLambda::testCaptureMutableInt$lambda$6)// 46
+      y.element = 100// 49
+      this.execute(TestNonInlineLambda::testCaptureMutableInt$lambda$7)// 50
+      y.element += x// 53
+      this.execute(TestNonInlineLambda::testCaptureMutableInt$lambda$8)// 54
    }// 57
 
    public fun testCaptureMutableObject(x: String) {
-      val y: ObjectRef = new ObjectRef();// 60
-      y.element = x;
-      this.execute(TestNonInlineLambda::testCaptureMutableObject$lambda$9);// 61
-      y.element = "${y.element}!!";// 64
-      this.execute(TestNonInlineLambda::testCaptureMutableObject$lambda$10);// 65
-      y.element = "${y.element}${y.element}${y.element}";// 68
-      this.execute(TestNonInlineLambda::testCaptureMutableObject$lambda$11);// 69
-      y.element = "Hello: ";// 72
-      this.execute(TestNonInlineLambda::testCaptureMutableObject$lambda$12);// 73
-      y.element = "${y.element}$x";// 76
-      this.execute(TestNonInlineLambda::testCaptureMutableObject$lambda$13);// 77
+      val y: ObjectRef = new ObjectRef()// 60
+      y.element = x
+      this.execute(TestNonInlineLambda::testCaptureMutableObject$lambda$9)// 61
+      y.element = "${y.element}!!"// 64
+      this.execute(TestNonInlineLambda::testCaptureMutableObject$lambda$10)// 65
+      y.element = "${y.element}${y.element}${y.element}"// 68
+      this.execute(TestNonInlineLambda::testCaptureMutableObject$lambda$11)// 69
+      y.element = "Hello: "// 72
+      this.execute(TestNonInlineLambda::testCaptureMutableObject$lambda$12)// 73
+      y.element = "${y.element}$x"// 76
+      this.execute(TestNonInlineLambda::testCaptureMutableObject$lambda$13)// 77
    }// 80
 
    public fun testCaptureAndMutateInt(x: Int) {
-      val y: IntRef = new IntRef();// 83
-      this.execute(TestNonInlineLambda::testCaptureAndMutateInt$lambda$14);// 84
-      y.element = 5 + x;// 89
-      this.execute(TestNonInlineLambda::testCaptureAndMutateInt$lambda$15);// 90
+      val y: IntRef = new IntRef()// 83
+      this.execute(TestNonInlineLambda::testCaptureAndMutateInt$lambda$14)// 84
+      y.element = 5 + x// 89
+      this.execute(TestNonInlineLambda::testCaptureAndMutateInt$lambda$15)// 90
    }// 95
 
    public fun testCaptureAndMutateString(x: String) {
-      val y: ObjectRef = new ObjectRef();// 98
-      y.element = "";
-      this.execute(TestNonInlineLambda::testCaptureAndMutateString$lambda$16);// 99
-      y.element = "Hello: $x";// 105
-      this.execute(TestNonInlineLambda::testCaptureAndMutateString$lambda$17);// 106
+      val y: ObjectRef = new ObjectRef()// 98
+      y.element = ""
+      this.execute(TestNonInlineLambda::testCaptureAndMutateString$lambda$16)// 99
+      y.element = "Hello: $x"// 105
+      this.execute(TestNonInlineLambda::testCaptureAndMutateString$lambda$17)// 106
    }// 112
 
    public fun testCapturePublicMutableIntField() {
-      this.execute(TestNonInlineLambda::testCapturePublicMutableIntField$lambda$18);
+      this.execute(TestNonInlineLambda::testCapturePublicMutableIntField$lambda$18)
    }// 118
 
    public fun testCapturePublicMutableStringField() {
-      this.execute(TestNonInlineLambda::testCapturePublicMutableStringField$lambda$19);
+      this.execute(TestNonInlineLambda::testCapturePublicMutableStringField$lambda$19)
    }// 124
 
    public fun testCapturePrivateMutableIntField() {
-      this.execute(TestNonInlineLambda::testCapturePrivateMutableIntField$lambda$20);
+      this.execute(TestNonInlineLambda::testCapturePrivateMutableIntField$lambda$20)
    }// 130
 
    public fun testCapturePrivateMutableStringField() {
-      this.execute(TestNonInlineLambda::testCapturePrivateMutableStringField$lambda$21);
+      this.execute(TestNonInlineLambda::testCapturePrivateMutableStringField$lambda$21)
    }// 136
 
    public open fun execute(block: () -> Unit) {
@@ -99,150 +99,150 @@ public open class TestNonInlineLambda {
 
    @JvmStatic
    fun `testCaptureInt$lambda$0`(`$y`: Int): Unit {
-      System.out.println(`$y`);// 9
-      return Unit.INSTANCE;// 10
+      System.out.println(`$y`)// 9
+      return Unit.INSTANCE// 10
    }
 
    @JvmStatic
    fun `testCaptureObject$lambda$1`(`$y`: java.lang.String): Unit {
-      System.out.println(`$y`);// 16
-      return Unit.INSTANCE;// 17
+      System.out.println(`$y`)// 16
+      return Unit.INSTANCE// 17
    }
 
    @JvmStatic
    fun `testCaptureIntIterationValue$lambda$2`(`$i`: Int): Unit {
-      System.out.println(`$i`);// 23
-      return Unit.INSTANCE;// 24
+      System.out.println(`$i`)// 23
+      return Unit.INSTANCE// 24
    }
 
    @JvmStatic
    fun `testCaptureObjectIterationValue$lambda$3`(`$i`: java.lang.String): Unit {
-      System.out.println(`$i`);// 31
-      return Unit.INSTANCE;// 32
+      System.out.println(`$i`)// 31
+      return Unit.INSTANCE// 32
    }
 
    @JvmStatic
    fun `testCaptureMutableInt$lambda$4`(`$y`: IntRef): Unit {
-      System.out.println(`$y`.element);// 39
-      return Unit.INSTANCE;// 40
+      System.out.println(`$y`.element)// 39
+      return Unit.INSTANCE// 40
    }
 
    @JvmStatic
    fun `testCaptureMutableInt$lambda$5`(`$y`: IntRef): Unit {
-      System.out.println(`$y`.element);// 43
-      return Unit.INSTANCE;// 44
+      System.out.println(`$y`.element)// 43
+      return Unit.INSTANCE// 44
    }
 
    @JvmStatic
    fun `testCaptureMutableInt$lambda$6`(`$y`: IntRef): Unit {
-      System.out.println(`$y`.element);// 47
-      return Unit.INSTANCE;// 48
+      System.out.println(`$y`.element)// 47
+      return Unit.INSTANCE// 48
    }
 
    @JvmStatic
    fun `testCaptureMutableInt$lambda$7`(`$y`: IntRef): Unit {
-      System.out.println(`$y`.element);// 51
-      return Unit.INSTANCE;// 52
+      System.out.println(`$y`.element)// 51
+      return Unit.INSTANCE// 52
    }
 
    @JvmStatic
    fun `testCaptureMutableInt$lambda$8`(`$y`: IntRef): Unit {
-      System.out.println(`$y`.element);// 55
-      return Unit.INSTANCE;// 56
+      System.out.println(`$y`.element)// 55
+      return Unit.INSTANCE// 56
    }
 
    @JvmStatic
    fun `testCaptureMutableObject$lambda$9`(`$y`: ObjectRef): Unit {
-      System.out.println(`$y`.element);// 62
-      return Unit.INSTANCE;// 63
+      System.out.println(`$y`.element)// 62
+      return Unit.INSTANCE// 63
    }
 
    @JvmStatic
    fun `testCaptureMutableObject$lambda$10`(`$y`: ObjectRef): Unit {
-      System.out.println(`$y`.element);// 66
-      return Unit.INSTANCE;// 67
+      System.out.println(`$y`.element)// 66
+      return Unit.INSTANCE// 67
    }
 
    @JvmStatic
    fun `testCaptureMutableObject$lambda$11`(`$y`: ObjectRef): Unit {
-      System.out.println(`$y`.element);// 70
-      return Unit.INSTANCE;// 71
+      System.out.println(`$y`.element)// 70
+      return Unit.INSTANCE// 71
    }
 
    @JvmStatic
    fun `testCaptureMutableObject$lambda$12`(`$y`: ObjectRef): Unit {
-      System.out.println(`$y`.element);// 74
-      return Unit.INSTANCE;// 75
+      System.out.println(`$y`.element)// 74
+      return Unit.INSTANCE// 75
    }
 
    @JvmStatic
    fun `testCaptureMutableObject$lambda$13`(`$y`: ObjectRef): Unit {
-      System.out.println(`$y`.element);// 78
-      return Unit.INSTANCE;// 79
+      System.out.println(`$y`.element)// 78
+      return Unit.INSTANCE// 79
    }
 
    @JvmStatic
    fun `testCaptureAndMutateInt$lambda$14`(`$y`: IntRef): Unit {
       while (`$y`.element < 10) {// 85
-         System.out.println(`$y`.element++);// 86
+         System.out.println(`$y`.element++)// 86
       }
 
-      return Unit.INSTANCE;// 88
+      return Unit.INSTANCE// 88
    }
 
    @JvmStatic
    fun `testCaptureAndMutateInt$lambda$15`(`$y`: IntRef): Unit {
       while (`$y`.element > 0) {// 91
-         val var1: Int = `$y`.element;// 92
-         `$y`.element += -1;
-         System.out.println(var1);
+         val var1: Int = `$y`.element// 92
+         `$y`.element += -1
+         System.out.println(var1)
       }
 
-      return Unit.INSTANCE;// 94
+      return Unit.INSTANCE// 94
    }
 
    @JvmStatic
    fun `testCaptureAndMutateString$lambda$16`(`$y`: ObjectRef): Unit {
       while ((`$y`.element as java.lang.String).length() < 10) {// 100
-         `$y`.element = " ${`$y`.element}";// 101
-         System.out.println(`$y`.element);// 102
+         `$y`.element = " ${`$y`.element}"// 101
+         System.out.println(`$y`.element)// 102
       }
 
-      return Unit.INSTANCE;// 104
+      return Unit.INSTANCE// 104
    }
 
    @JvmStatic
    fun `testCaptureAndMutateString$lambda$17`(`$y`: ObjectRef): Unit {
       while (!StringsKt.isBlank(`$y`.element as java.lang.CharSequence)) {// 107
-         System.out.println();// 108
-         `$y`.element = StringsKt.drop(`$y`.element as java.lang.String, 1);// 109
+         System.out.println()// 108
+         `$y`.element = StringsKt.drop(`$y`.element as java.lang.String, 1)// 109
       }
 
-      return Unit.INSTANCE;// 111
+      return Unit.INSTANCE// 111
    }
 
    @JvmStatic
    fun `testCapturePublicMutableIntField$lambda$18`(`this$0`: TestNonInlineLambda): Unit {
-      val var1: Int = `this$0`.intField++;// 117
-      return Unit.INSTANCE;
+      val var1: Int = `this$0`.intField++// 117
+      return Unit.INSTANCE
    }
 
    @JvmStatic
    fun `testCapturePublicMutableStringField$lambda$19`(`this$0`: TestNonInlineLambda): Unit {
-      `this$0`.stringField = "${`this$0`.stringField}!";// 123
-      return Unit.INSTANCE;
+      `this$0`.stringField = "${`this$0`.stringField}!"// 123
+      return Unit.INSTANCE
    }
 
    @JvmStatic
    fun `testCapturePrivateMutableIntField$lambda$20`(`this$0`: TestNonInlineLambda): Unit {
-      val var1: Int = `this$0`.privateIntField++;// 129
-      return Unit.INSTANCE;
+      val var1: Int = `this$0`.privateIntField++// 129
+      return Unit.INSTANCE
    }
 
    @JvmStatic
    fun `testCapturePrivateMutableStringField$lambda$21`(`this$0`: TestNonInlineLambda): Unit {
-      `this$0`.privateStringField = "${`this$0`.privateStringField}!";// 135
-      return Unit.INSTANCE;
+      `this$0`.privateStringField = "${`this$0`.privateStringField}!"// 135
+      return Unit.INSTANCE
    }
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestNothingReturns.dec
+++ b/plugins/kotlin/testData/results/pkg/TestNothingReturns.dec
@@ -3,46 +3,46 @@ package pkg
 public class TestNothingReturns {
    public fun loop(): Nothing {
       while (true) {
-         System.out.println("loop");// 6
+         System.out.println("loop")// 6
       }
    }
 
    public fun test1(): Nothing {
-      this.loop();// 11
-      throw new KotlinNothingValueException();
+      this.loop()// 11
+      throw new KotlinNothingValueException()
    }
 
    public fun test2(): Long {
-      this.test1();// 15
-      throw new KotlinNothingValueException();
+      this.test1()// 15
+      throw new KotlinNothingValueException()
    }
 
    public fun test3(i: Int): Int {
       if (i == 0) {// 19
-         this.loop();// 20
-         throw new KotlinNothingValueException();
+         this.loop()// 20
+         throw new KotlinNothingValueException()
       } else {
-         return this.test3(i - 1) + 1;// 23
+         return this.test3(i - 1) + 1// 23
       }
    }
 
    public fun test4() {
-      this.loop();// 27
-      throw new KotlinNothingValueException();
+      this.loop()// 27
+      throw new KotlinNothingValueException()
    }
 
    public fun test5(s: String): String {
-      StringsKt.repeat(s as java.lang.CharSequence, 5);// 32
-      this.loop();
-      throw new KotlinNothingValueException();
+      StringsKt.repeat(s as java.lang.CharSequence, 5)// 32
+      this.loop()
+      throw new KotlinNothingValueException()
    }
 
    public fun test6(s: String?): String {
       if (s == null) {// 36
-         this.loop();
-         throw new KotlinNothingValueException();
+         this.loop()
+         throw new KotlinNothingValueException()
       } else {
-         return s;
+         return s
       }
    }
 }

--- a/plugins/kotlin/testData/results/pkg/TestNullable.dec
+++ b/plugins/kotlin/testData/results/pkg/TestNullable.dec
@@ -5,11 +5,11 @@ public class TestNullable {
    }// 6
 
    public fun nullableReturn(): String? {
-      return null;// 9
+      return null// 9
    }
 
    public fun nullableGenerics(v: List<String?>): List<String?>? {
-      return v;// 13
+      return v// 13
    }
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestNullableOperator.dec
+++ b/plugins/kotlin/testData/results/pkg/TestNullableOperator.dec
@@ -2,71 +2,71 @@ package pkg
 
 public class TestNullableOperator {
    public fun test(x: Int?): Int {
-      return x ?: 0;// 5
+      return x ?: 0// 5
    }
 
    public fun test2(x: String?): String {
-      var var10000: java.lang.String = x;// 9
+      var var10000: java.lang.String = x// 9
       if (x == null) {
-         var10000 = "default";
+         var10000 = "default"
       }
 
-      return var10000;
+      return var10000
    }
 
    public fun test2_1(x: Any?): Any {
-      var var10000: Any = x;// 13
+      var var10000: Any = x// 13
       if (x == null) {
-         var10000 = "default";
+         var10000 = "default"
       }
 
-      return var10000;
+      return var10000
    }
 
    public fun test2_2(x: Any?): Any {
-      var var10000: Any = x;// 17
+      var var10000: Any = x// 17
       if (x == null) {
-         var10000 = "default";
+         var10000 = "default"
       }
 
-      return var10000;
+      return var10000
    }
 
    public fun test3(x: Int?): Int {
       if (x != null) {// 21
-         return x;
+         return x
       } else {
-         throw new Exception();
+         throw new Exception()
       }
    }
 
    public fun test4(x: Exception?) {
       if (x != null) {// 25
-         x.printStackTrace();
+         x.printStackTrace()
       }
    }// 26
 
    public fun test5(x: Exception?) {
       if (x != null) {// 29
-         x.printStackTrace();
+         x.printStackTrace()
       } else {
-         throw new Exception();
+         throw new Exception()
       }
    }
 
    public fun test6(x: Int?): Int {
       if (x != null) {// 33
-         val y: Int = x;
-         System.out.println(y);// 35
-         return y;// 37
+         val y: Int = x
+         System.out.println(y)// 35
+         return y// 37
       } else {
-         return 0;
+         return 0
       }
    }
 
    public fun test6_1(x: Int?) {
       if (x != null) {// 41
-         System.out.println(x);// 43
+         System.out.println(x)// 43
       }
    }
 }

--- a/plugins/kotlin/testData/results/pkg/TestObject.dec
+++ b/plugins/kotlin/testData/results/pkg/TestObject.dec
@@ -6,12 +6,12 @@ public object TestObject {
    public const val objectConstVal: Int = 926
 
    public fun objectFun() {
-      objectVar += -1;// 5
+      objectVar += -1// 5
    }// 6
 
    @JvmStatic
    public fun objectJvmStaticFun() {
-      val var0: Int = objectVar++;// 16
+      val var0: Int = objectVar++// 16
    }// 17
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestParams.dec
+++ b/plugins/kotlin/testData/results/pkg/TestParams.dec
@@ -2,28 +2,28 @@ package pkg
 
 public class TestParams {
    public fun printMessageUnit(message: String) {
-      System.out.println(message);// 5
+      System.out.println(message)// 5
    }// 6
 
    public fun printMessageVoid(message: String) {
-      System.out.println(message);// 9
+      System.out.println(message)// 9
    }// 10
 
    public fun multiply(x: Int, y: Int): Int {
-      return x * y;// 12
+      return x * y// 12
    }
 
    public fun multiplyBraces(x: Int, y: Int): Int {
-      return x * y;// 15
+      return x * y// 15
    }
 
    public fun printMessageWithPrefix(message: String, prefix: String = "Info") {
-      System.out.println("[$prefix] $message");// 19
+      System.out.println("[$prefix] $message")// 19
    }// 20
 
    public fun callPrintMessage() {
-      printMessageWithPrefix$default(this, "Test", null, 2, null);// 23
-      this.printMessageWithPrefix("Test", "Debug");// 24
+      printMessageWithPrefix$default(this, "Test", null, 2, null)// 23
+      this.printMessageWithPrefix("Test", "Debug")// 24
    }// 25
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestPoorNames.dec
+++ b/plugins/kotlin/testData/results/pkg/TestPoorNames.dec
@@ -17,9 +17,9 @@ public class TestPoorNames {
    }// 17
 
    public fun test() {
-      new TestPoorNames.Class with spaces();
-      this.Dangerous function name?!();// 23
-      this.functionWithParameters(42, "test");// 24
+      new TestPoorNames.Class with spaces()
+      this.Dangerous function name?!()// 23
+      this.functionWithParameters(42, "test")// 24
    }// 25
 
    public class `Class with spaces`

--- a/plugins/kotlin/testData/results/pkg/TestReflection.dec
+++ b/plugins/kotlin/testData/results/pkg/TestReflection.dec
@@ -5,31 +5,31 @@ import kotlin.reflect.KFunction
 
 public class TestReflection {
    public fun testClassReference() {
-      System.out.println(TestReflection::class);// 5
-      System.out.println(TestReflection::class.java);// 6
+      System.out.println(TestReflection::class)// 5
+      System.out.println(TestReflection::class.java)// 6
    }// 7
 
    public fun testPrimitiveWrapper() {
-      System.out.println(Int::class);// 10
-      System.out.println(Integer::class.javaObjectType);// 11
+      System.out.println(Int::class)// 10
+      System.out.println(Integer::class.javaObjectType)// 11
    }// 12
 
    public fun testPrimitiveType() {
-      System.out.println(Int::class.javaPrimitiveType);// 15
+      System.out.println(Int::class.javaPrimitiveType)// 15
    }// 16
 
    public fun testInferredPrimitive() {
-      System.out.println(Int::class.javaPrimitiveType);// 19
+      System.out.println(Int::class.javaPrimitiveType)// 19
    }// 20
 
    public fun testFunctionReference() {
-      val f: KFunction = <unknownclass>.INSTANCE as KFunction;// 23
-      System.out.println(<unknownclass>.INSTANCE as KFunction);// 24
-      (f as Function1).invoke(new TestReflection());// 25
+      val f: KFunction = <unknownclass>.INSTANCE as KFunction// 23
+      System.out.println(<unknownclass>.INSTANCE as KFunction)// 24
+      (f as Function1).invoke(new TestReflection())// 25
    }// 26
 
    public fun testThis() {
-      System.out.println(this.getClass()::class);// 29 30
+      System.out.println(this.getClass()::class)// 29 30
    }// 31
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestSafeCasts.dec
+++ b/plugins/kotlin/testData/results/pkg/TestSafeCasts.dec
@@ -2,88 +2,88 @@ package pkg
 
 public class TestSafeCasts {
    public fun test(obj: Any): Boolean {
-      val t: Int = obj as? Int;// 5
+      val t: Int = obj as? Int// 5
       if ((obj as? Int) != null) {// 7
          if (t == 1) {
-            return true;
+            return true
          }
       }
 
-      return false;
+      return false
    }
 
    public fun testTestBefore(obj: Any): Boolean? {
       if (obj !is Int) {// 11
-         return null;// 12
+         return null// 12
       } else {
-         val t: Int = obj as? Int;// 15
+         val t: Int = obj as? Int// 15
          if ((obj as? Int) != null) {// 17
             if (t == 1) {
-               return true;
+               return true
             }
          }
 
-         return false;
+         return false
       }
    }
 
    public fun testHardIncompatible(obj: Int): Boolean {
-      return (obj as? java.lang.String) == "1";// 21 23
+      return (obj as? java.lang.String) == "1"// 21 23
    }
 
    public fun testSmartCastIncompatible(obj: Any): Boolean {
-      return obj is Int && (obj as? java.lang.String) == "1";// 27 31 33
+      return obj is Int && (obj as? java.lang.String) == "1"// 27 31 33
    }
 
    public fun testCastNonNullToNullable(obj: Any): Boolean {
-      val t: Int = obj as? Int;// 37
+      val t: Int = obj as? Int// 37
       if ((obj as? Int) != null) {// 39
          if (t == 1) {
-            return true;
+            return true
          }
       }
 
-      return false;
+      return false
    }
 
    public fun testBeforeNonNullToNullable(obj: Any): Boolean? {
       if (obj !is Int) {// 43
-         return null;// 44
+         return null// 44
       } else {
-         val t: Int = obj as? Int;// 47
+         val t: Int = obj as? Int// 47
          if ((obj as? Int) != null) {// 49
             if (t == 1) {
-               return true;
+               return true
             }
          }
 
-         return false;
+         return false
       }
    }
 
    public fun testCastNullableToNullable(obj: Any?): Boolean {
-      val t: Int = obj as? Int;// 53
+      val t: Int = obj as? Int// 53
       if ((obj as? Int) != null) {// 55
          if (t == 1) {
-            return true;
+            return true
          }
       }
 
-      return false;
+      return false
    }
 
    public fun testBeforeNullableToNullable(obj: Any?): Boolean? {
       if (obj != null && obj !is Int) {// 59
-         return null;// 60
+         return null// 60
       } else {
-         val t: Int = obj as? Int;// 63
+         val t: Int = obj as? Int// 63
          if ((obj as? Int) != null) {// 65
             if (t == 1) {
-               return true;
+               return true
             }
          }
 
-         return false;
+         return false
       }
    }
 }

--- a/plugins/kotlin/testData/results/pkg/TestSealedHierarchy.dec
+++ b/plugins/kotlin/testData/results/pkg/TestSealedHierarchy.dec
@@ -5,7 +5,7 @@ public sealed class TestSealedHierarchy protected constructor() {
       public final val x: Int
 
       init {
-         this.x = x;
+         this.x = x
       }
    }
 

--- a/plugins/kotlin/testData/results/pkg/TestShadowParam.dec
+++ b/plugins/kotlin/testData/results/pkg/TestShadowParam.dec
@@ -2,10 +2,10 @@ package pkg
 
 public class TestShadowParam {
    public fun test(x: Int) {
-      val xx: Int = x - 1;// 5 6
-      System.out.println(x - 1);// 7
+      val xx: Int = x - 1// 5 6
+      System.out.println(x - 1)// 7
       if (xx < 0) {// 8
-         System.out.println(xx);// 9
+         System.out.println(xx)// 9
       }
    }// 11
 }

--- a/plugins/kotlin/testData/results/pkg/TestSmartCasts.dec
+++ b/plugins/kotlin/testData/results/pkg/TestSmartCasts.dec
@@ -3,89 +3,89 @@ package pkg
 public class TestSmartCasts {
    public fun testWhen(o: Any?): String {
       if (o is java.lang.String) {// 19 20
-         return o as java.lang.String;// 21
+         return o as java.lang.String// 21
       } else {
          if (o is TestSmartCasts.A.B) {// 24
-            System.out.println("B: $o");
+            System.out.println("B: $o")
          } else {
             if (o !is TestSmartCasts.A.C) {// 25
                if (o is Pair) {// 26
-                  return "<${this.testWhen((o as Pair).getFirst())}, ${this.testWhen((o as Pair).getSecond())}>";
+                  return "<${this.testWhen((o as Pair).getFirst())}, ${this.testWhen((o as Pair).getSecond())}>"
                }
 
                if (o == null) {// 27
-                  return "null";
+                  return "null"
                }
 
-               return "else: $o";// 28
+               return "else: $o"// 28
             }
 
-            System.out.println("C: $o");
+            System.out.println("C: $o")
          }
 
-         return (o as TestSmartCasts.A).test();// 31
+         return (o as TestSmartCasts.A).test()// 31
       }
    }
 
    public fun testIf(a: Any?): String {
-      return if (a !is TestSmartCasts.A.B && a !is TestSmartCasts.A.C) "else: $a" else (a as TestSmartCasts.A).test();// 35 36 39
+      return if (a !is TestSmartCasts.A.B && a !is TestSmartCasts.A.C) "else: $a" else (a as TestSmartCasts.A).test()// 35 36 39
    }
 
    public fun testIf2(a: Any?): String {
       if (a is TestSmartCasts.A) {// 43
          if (a is TestSmartCasts.A.B || a is TestSmartCasts.A.C) {// 44
-            System.out.println((a as TestSmartCasts.A).test());// 45
+            System.out.println((a as TestSmartCasts.A).test())// 45
          }
 
          if (a is TestSmartCasts.A.B) {// 48
             if (a is TestSmartCasts.A.C) {// 49
-               System.out.println((a as TestSmartCasts.A.B).testB());// 50
-               System.out.println((a as TestSmartCasts.A.C).testC());// 51
+               System.out.println((a as TestSmartCasts.A.B).testB())// 50
+               System.out.println((a as TestSmartCasts.A.C).testC())// 51
             }
 
             if (a is TestSmartCasts.A.C && (a as TestSmartCasts.A.C).testC() == "C" || a is TestSmartCasts.A.B) {// 54
-               System.out.println((a as TestSmartCasts.A.B).testB());// 55
+               System.out.println((a as TestSmartCasts.A.B).testB())// 55
             }
          }
       }
 
-      return "else: $a";// 60
+      return "else: $a"// 60
    }
 
    public fun testCast(a: Any?) {
-      System.out.println(a);// 64
-      System.out.println("hello");// 66
-      System.out.println(a);// 67
-      (a as java.lang.String).charAt(0);// 68
-      System.out.println((a as java.lang.String).charAt(0));// 69
+      System.out.println(a)// 64
+      System.out.println("hello")// 66
+      System.out.println(a)// 67
+      (a as java.lang.String).charAt(0)// 68
+      System.out.println((a as java.lang.String).charAt(0))// 69
    }// 70
 
    public fun testSealedIf(a: pkg.TestSmartCasts.A): String {
       if (a is TestSmartCasts.A.B) {// 73
-         return (a as TestSmartCasts.A.B).testB();// 74
+         return (a as TestSmartCasts.A.B).testB()// 74
       } else {
-         return if (a is TestSmartCasts.A.C) (a as TestSmartCasts.A.C).testC() else a.test();// 75 76 78
+         return if (a is TestSmartCasts.A.C) (a as TestSmartCasts.A.C).testC() else a.test()// 75 76 78
       }
    }
 
    public fun testDoubleType(t: List<String>): String {
-      return if (t is TestSmartCasts.X) (t as TestSmartCasts.X).woo(t as MutableIterable<*>) else t.get(0) as java.lang.String;// 83 84 87
+      return if (t is TestSmartCasts.X) (t as TestSmartCasts.X).woo(t as MutableIterable<*>) else t.get(0) as java.lang.String// 83 84 87
    }
 
    public sealed class A protected constructor() {
       public fun test(): String {
-         return "";// 15
+         return ""// 15
       }
 
       public class B : TestSmartCasts.A() {// 8
          public fun testB(): String {
-            return "B";// 9
+            return "B"// 9
          }
       }
 
       public class C : TestSmartCasts.A() {// 11
          public fun testC(): String {
-            return "C";// 12
+            return "C"// 12
          }
       }
    }
@@ -98,7 +98,7 @@ public class TestSmartCasts {
       internal class DefaultImpls {
          @JvmStatic
          fun woo(`$this`: TestSmartCasts.X, `$receiver`: MutableIterable<*>): java.lang.String {
-            return "A";// 5
+            return "A"// 5
          }
       }
    }

--- a/plugins/kotlin/testData/results/pkg/TestStringInterpolation.dec
+++ b/plugins/kotlin/testData/results/pkg/TestStringInterpolation.dec
@@ -4,23 +4,23 @@ public class TestStringInterpolation {
    public final val x: Int = 5// 16
 
    public fun stringInterpolation(x: Int, y: String) {
-      System.out.println("$x $y");// 5
+      System.out.println("$x $y")// 5
    }// 6
 
    public fun testConstant(x: Int) {
-      System.out.println("$x 5");// 9
+      System.out.println("$x 5")// 9
    }// 10
 
    public fun testExpression(x: Int) {
-      System.out.println("$x ${x + 1}");// 13
+      System.out.println("$x ${x + 1}")// 13
    }// 14
 
    public fun testProperty() {
-      System.out.println("${this.x}!");// 18
+      System.out.println("${this.x}!")// 18
    }// 19
 
    public fun testLiteralClass() {
-      System.out.println("${TestStringInterpolation::class.java}!");// 22
+      System.out.println("${TestStringInterpolation::class.java}!")// 22
    }// 23
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestSynchronized.dec
+++ b/plugins/kotlin/testData/results/pkg/TestSynchronized.dec
@@ -3,7 +3,7 @@ package pkg
 public class TestSynchronized {
    public fun test() {
       synchronized (this) {// 5
-         System.out.println("Hello");// 6
+         System.out.println("Hello")// 6
       }
    }
 }

--- a/plugins/kotlin/testData/results/pkg/TestTailrecFunctions.dec
+++ b/plugins/kotlin/testData/results/pkg/TestTailrecFunctions.dec
@@ -2,17 +2,17 @@ package pkg
 
 public class TestTailrecFunctions {
    public tailrec fun sum(x: Long, sum: Long): Long {
-      var var5: TestTailrecFunctions = this;// 4
+      var var5: TestTailrecFunctions = this// 4
 
       while (x != 0L) {// 5
-         val var7: Long = x - 1L;
-         val var9: Long = sum + x;
-         var5 = var5;// 6
-         x = var7;
-         sum = var9;
+         val var7: Long = x - 1L
+         val var9: Long = sum + x
+         var5 = var5// 6
+         x = var7
+         sum = var9
       }
 
-      return sum;
+      return sum
    }
 
    public tailrec fun testFinally() {
@@ -20,10 +20,10 @@ public class TestTailrecFunctions {
          try {
             ;
          } catch (var2: java.lang.Throwable) {
-            this.testFinally();
+            this.testFinally()
          }
 
-         this.testFinally();// 13
+         this.testFinally()// 13
       }
    }
 
@@ -31,15 +31,15 @@ public class TestTailrecFunctions {
       try {
          ;
       } catch (var2: java.lang.Throwable) {
-         return this.testFinallyReturn();
+         return this.testFinallyReturn()
       }
 
-      return this.testFinallyReturn();// 21
+      return this.testFinallyReturn()// 21
    }
 
    public tailrec fun fooTry() {
       try {
-         this.fooTry();// 27
+         this.fooTry()// 27
       } catch (var2: java.lang.Throwable) {// 29
       }
    }// 31
@@ -49,70 +49,70 @@ public class TestTailrecFunctions {
          run label33@{
             try {
                try {
-                  this.testTryCatchFinally();// 35
+                  this.testTryCatchFinally()// 35
                   break label33;
                } catch (var2: Exception) {// 36
-                  this.testTryCatchFinally();// 37
+                  this.testTryCatchFinally()// 37
                }
             } catch (var3: java.lang.Throwable) {
-               this.testTryCatchFinally();
+               this.testTryCatchFinally()
             }
 
-            this.testTryCatchFinally();// 39
-            return;// 41
+            this.testTryCatchFinally()// 39
+            return// 41
          }
 
-         this.testTryCatchFinally();
+         this.testTryCatchFinally()
       }
    }
 
    public tailrec fun fastPow(x: Long, n: Long, acc: Long = 1L): Long {
-      var var7: TestTailrecFunctions = this;// 43
+      var var7: TestTailrecFunctions = this// 43
 
       while (n != 0L) {// 44
          if (n % 2 == 0L) {// 45
-            val var9: Long = x * x;
-            val var11: Long = n / 2;
-            var7 = var7;
-            x = var9;
-            n = var11;
-            acc = acc;
+            val var9: Long = x * x
+            val var11: Long = n / 2
+            var7 = var7
+            x = var9
+            n = var11
+            acc = acc
          } else {
-            val var15: Long = n - 1L;
-            val var13: Long = acc * x;
-            var7 = var7;// 46
-            x = x;
-            n = var15;
-            acc = var13;
+            val var15: Long = n - 1L
+            val var13: Long = acc * x
+            var7 = var7// 46
+            x = x
+            n = var15
+            acc = var13
          }
       }
 
-      return acc;
+      return acc
    }
 
    public tailrec fun fastPow(x: Long, n: Long): Long {
-      var var5: TestTailrecFunctions = this;// 49
+      var var5: TestTailrecFunctions = this// 49
 
-      var var10000: Long;
+      var var10000: Long
       while (true) {
          if (n == 0L) {// 50
-            var10000 = 1L;
+            var10000 = 1L
             break
          }
 
          if (n % 2 != 0L) {// 51
-            var10000 = x * var5.fastPow(x, n - 1L);// 52
+            var10000 = x * var5.fastPow(x, n - 1L)// 52
             break
          }
 
-         val var7: Long = x * x;
-         val var9: Long = n / 2;
-         var5 = var5;
-         x = var7;
-         n = var9;
+         val var7: Long = x * x
+         val var9: Long = n / 2
+         var5 = var5
+         x = var7
+         n = var9
       }
 
-      return var10000;// 53
+      return var10000// 53
    }
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestTopLevelKt.dec
+++ b/plugins/kotlin/testData/results/pkg/TestTopLevelKt.dec
@@ -10,8 +10,8 @@ public fun topLevelFun() {
 }// 5
 
 public fun interpolateTopLevel() {
-   System.out.println("topLevelVar = ${topLevelVar}");// 14
-   System.out.println("topLevelConstVal = 926");// 15
+   System.out.println("topLevelVar = ${topLevelVar}")// 14
+   System.out.println("topLevelConstVal = 926")// 15
 }// 16
 
 class 'pkg/TestTopLevelKt' {

--- a/plugins/kotlin/testData/results/pkg/TestTryCatchExpressions.dec
+++ b/plugins/kotlin/testData/results/pkg/TestTryCatchExpressions.dec
@@ -6,112 +6,112 @@ import kotlin.jvm.internal.SourceDebugExtension
 @SourceDebugExtension(["SMAP\nTestTryCatchExpressions.kt\nKotlin\n*S Kotlin\n*F\n+ 1 TestTryCatchExpressions.kt\npkg/TestTryCatchExpressions\n+ 2 fake.kt\nkotlin/jvm/internal/FakeKt\n*L\n1#1,59:1\n1#2:60\n*E\n"])
 public class TestTryCatchExpressions {
    public fun test0(s: String) {
-      var var2: java.lang.String;
+      var var2: java.lang.String
       try {
-         var2 = StringsKt.repeat(s as java.lang.CharSequence, 5);// 9
+         var2 = StringsKt.repeat(s as java.lang.CharSequence, 5)// 9
       } catch (var4: RuntimeException) {// 10
-         var var10000: java.lang.String = var4.getMessage();// 11
+         var var10000: java.lang.String = var4.getMessage()// 11
          if (var10000 == null) {
-            var10000 = "ERROR";
+            var10000 = "ERROR"
          }
 
-         var2 = var10000;
+         var2 = var10000
       }
 
-      System.out.print(var2);// 7
+      System.out.print(var2)// 7
    }// 14
 
    public fun test1(a: String, b: String) {
-      var x: java.lang.String = a;// 17
-      var var6: TestTryCatchExpressions = this;// 19
+      var x: java.lang.String = a// 17
+      var var6: TestTryCatchExpressions = this// 19
 
-      var var4: java.lang.String;
-      var var10000: TestTryCatchExpressions;
+      var var4: java.lang.String
+      var var10000: TestTryCatchExpressions
       try {
-         var10000 = var6;
-         var4 = StringsKt.repeat(x as java.lang.CharSequence, 5);// 20
+         var10000 = var6
+         var4 = StringsKt.repeat(x as java.lang.CharSequence, 5)// 20
       } catch (var9: RuntimeException) {// 21
-         var10000 = this;
-         x = b;// 22
-         var var10001: java.lang.String = var9.getMessage();// 23
+         var10000 = this
+         x = b// 22
+         var var10001: java.lang.String = var9.getMessage()// 23
          if (var10001 == null) {
-            var10001 = "ERROR";
+            var10001 = "ERROR"
          }
 
-         var4 = var10001;
+         var4 = var10001
       }
 
-      val var7: java.lang.String = var4;// 24
-      var6 = var10000;
+      val var7: java.lang.String = var4// 24
+      var6 = var10000
 
-      var var13: java.lang.String;
+      var var13: java.lang.String
       try {
-         var10000 = var6;
-         var13 = var7;
-         var4 = StringsKt.repeat(x as java.lang.CharSequence, 5);// 25
+         var10000 = var6
+         var13 = var7
+         var4 = StringsKt.repeat(x as java.lang.CharSequence, 5)// 25
       } catch (var8: RuntimeException) {// 26
-         var10000 = var10000;
-         var13 = var4;
-         var var10002: java.lang.String = var8.getMessage();// 27
+         var10000 = var10000
+         var13 = var4
+         var var10002: java.lang.String = var8.getMessage()// 27
          if (var10002 == null) {
-            var10002 = "ERROR";
+            var10002 = "ERROR"
          }
 
-         var4 = var10002;
+         var4 = var10002
       }
 
-      var10000.test0("$var13$var4");// 18
+      var10000.test0("$var13$var4")// 18
    }// 30
 
    public fun test2(a: String, b: String) {
-      var var15: java.lang.String = a;// 33
-      var var7: TestTryCatchExpressions = this;
+      var var15: java.lang.String = a// 33
+      var var7: TestTryCatchExpressions = this
 
-      var var4: java.lang.String;
-      var var10000: TestTryCatchExpressions;
+      var var4: java.lang.String
+      var var10000: TestTryCatchExpressions
       try {
-         var10000 = var7;
+         var10000 = var7
          if (a.length() != b.length()) {// 35
-            return;// 36
+            return// 36
          }
 
-         var15 = b;// 38
-         this.test0(b);// 39
-         var4 = b;// 40
+         var15 = b// 38
+         this.test0(b)// 39
+         var4 = b// 40
       } catch (var13: IOException) {// 41
-         var10000 = this;
-         var15 = a;// 42
-         this.test1(a, a);// 43
-         var4 = a;// 44
+         var10000 = this
+         var15 = a// 42
+         this.test1(a, a)// 43
+         var4 = a// 44
       } catch (var14: RuntimeException) {// 46
-         var10000 = this;// 45
-         var15 = if (var15 == a) b else a;// 47 49
-         var4 = var15;// 51
+         var10000 = this// 45
+         var15 = if (var15 == a) b else a// 47 49
+         var4 = var15// 51
       }
 
-      val var8: java.lang.String = var4;// 52
-      var7 = var10000;
+      val var8: java.lang.String = var4// 52
+      var7 = var10000
 
-      var var10001: java.lang.String;
+      var var10001: java.lang.String
       try {
-         var4 = StringsKt.repeat(var15 as java.lang.CharSequence, 5);
-         var15 = var4;
-         var10000 = var7;
-         var10001 = var8;
-         var4 = var4;// 53
+         var4 = StringsKt.repeat(var15 as java.lang.CharSequence, 5)
+         var15 = var4
+         var10000 = var7
+         var10001 = var8
+         var4 = var4// 53
       } catch (var12: RuntimeException) {// 54
-         var10000 = var10000;
-         var10001 = var4;
-         System.out.println(var15);// 55
-         var var10003: java.lang.String = var12.getMessage();
+         var10000 = var10000
+         var10001 = var4
+         System.out.println(var15)// 55
+         var var10003: java.lang.String = var12.getMessage()
          if (var10003 == null) {
-            var10003 = "";
+            var10003 = ""
          }
 
-         var4 = "$var15!!$var10003";// 56
+         var4 = "$var15!!$var10003"// 56
       }
 
-      var10000.test1(var10001, var4);// 34
+      var10000.test1(var10001, var4)// 34
    }// 58
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestTryFinallyExpressions.dec
+++ b/plugins/kotlin/testData/results/pkg/TestTryFinallyExpressions.dec
@@ -8,40 +8,40 @@ public class TestTryFinallyExpressions {
    public fun test0(s: String) {
       run label23@{
          try {
-            val var2: java.lang.String = StringsKt.repeat(s as java.lang.CharSequence, 5);// 8
+            val var2: java.lang.String = StringsKt.repeat(s as java.lang.CharSequence, 5)// 8
          } catch (var4: java.lang.Throwable) {
-            System.out.println("bye");
+            System.out.println("bye")
          }
 
-         System.out.println("bye");// 10
+         System.out.println("bye")// 10
       }
    }
 
    public fun test1(a: String, b: String) {
       run label45@{
-         var x: java.lang.String = a;// 15
+         var x: java.lang.String = a// 15
 
          try {
-            val var4: java.lang.String = StringsKt.repeat(x as java.lang.CharSequence, 5);// 17
+            val var4: java.lang.String = StringsKt.repeat(x as java.lang.CharSequence, 5)// 17
          } catch (var9: java.lang.Throwable) {
             ;
          }
 
-         x = b;// 19
+         x = b// 19
 
          try {
-            val var15: java.lang.String = StringsKt.repeat(x as java.lang.CharSequence, 5);// 21
+            val var15: java.lang.String = StringsKt.repeat(x as java.lang.CharSequence, 5)// 21
          } catch (var8: java.lang.Throwable) {
-            System.out.println(a);
+            System.out.println(a)
          }
 
-         System.out.println(a);// 23
+         System.out.println(a)// 23
       }
    }
 
    public fun test2(a: String, b: String) {
       run label140@{
-         var var19: java.lang.String = a;// 28
+         var var19: java.lang.String = a// 28
 
          run label139@{
             run label138@{
@@ -52,35 +52,35 @@ public class TestTryFinallyExpressions {
                            return@label139
                         }
 
-                        var19 = b;// 33
-                        this.test0(b);// 34
+                        var19 = b// 33
+                        this.test0(b)// 34
                         return@label137
                      } catch (var11: IOException) {// 36
-                        var19 = a;// 37
-                        this.test1(a, a);// 38
-                        val var4: java.lang.String = a;// 39
+                        var19 = a// 37
+                        this.test1(a, a)// 38
+                        val var4: java.lang.String = a// 39
                      }
                   } catch (var12: java.lang.Throwable) {
-                     var19 = if (var19 == a) b else a;// 41 42 44
+                     var19 = if (var19 == a) b else a// 41 42 44
                   }
 
-                  var19 = if (var19 == a) b else a;
+                  var19 = if (var19 == a) b else a
                   return@label138// 46
                }
 
-               var19 = if (var19 == a) b else a;
+               var19 = if (var19 == a) b else a
             }
 
             try {
-               var19 = StringsKt.repeat(var19 as java.lang.CharSequence, 5);// 47
+               var19 = StringsKt.repeat(var19 as java.lang.CharSequence, 5)// 47
             } catch (var10: java.lang.Throwable) {
-               System.out.println(var19);
+               System.out.println(var19)
             }
 
-            System.out.println(var19);// 49
+            System.out.println(var19)// 49
          }
 
-         var19 = if (a == a) b else a;
+         var19 = if (a == a) b else a
       }
    }
 }

--- a/plugins/kotlin/testData/results/pkg/TestVars.dec
+++ b/plugins/kotlin/testData/results/pkg/TestVars.dec
@@ -2,26 +2,26 @@ package pkg
 
 public class TestVars {
    public fun testVar() {
-      System.out.println("initial");// 5 6
+      System.out.println("initial")// 5 6
    }// 9
 
    public fun testVal() {
-      System.out.println("initial");// 12 13
+      System.out.println("initial")// 12 13
    }// 16
 
    public fun testPhi(bl: Boolean) {
-      val var3: Byte;
+      val var3: Byte
       if (bl) {// 21
-         var3 = 1;// 22
+         var3 = 1// 22
       } else {
-         var3 = 2;// 24
+         var3 = 2// 24
       }
 
-      System.out.println(var3);// 27
+      System.out.println(var3)// 27
    }// 28
 
    public fun testIfExpr(bl: Boolean) {
-      System.out.println(if (bl) 1 else 2);// 31 32 34 37
+      System.out.println(if (bl) 1 else 2)// 31 32 34 37
    }// 38
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestWhen.dec
+++ b/plugins/kotlin/testData/results/pkg/TestWhen.dec
@@ -3,116 +3,116 @@ package pkg
 public class TestWhen {
    public fun testStatement(obj: Any) {
       if (obj == 1) {// 5 6
-         System.out.println("1");
+         System.out.println("1")
       } else if (obj == "2") {// 7
-         System.out.println("2");
+         System.out.println("2")
       } else if (obj is java.lang.Double) {// 8
-         System.out.println("Double");
+         System.out.println("Double")
       } else if (obj !is java.lang.Long) {// 9
-         System.out.println("Not Long");
+         System.out.println("Not Long")
       } else {
-         System.out.println("else");// 10
+         System.out.println("else")// 10
       }
    }// 12
 
    public fun testStatement2(a: Any, b: Any) {
       if (a == 15) {// 16
-         System.out.println("a == 15");
+         System.out.println("a == 15")
       } else if (a == "!!") {// 17
-         System.out.println("a == !!");
+         System.out.println("a == !!")
       } else if (a is Int) {// 18
-         System.out.println("a is Int");
+         System.out.println("a is Int")
       } else if (a is java.lang.String) {// 19
-         System.out.println("a is String");
+         System.out.println("a is String")
       } else if (b is java.lang.Double) {// 20
-         System.out.println("b is Double");
+         System.out.println("b is Double")
       } else if (a is Unit) {// 21
-         System.out.println("a is Unit");
+         System.out.println("a is Unit")
       } else {
-         System.out.println("else");// 22
+         System.out.println("else")// 22
       }
    }// 24
 
    public fun testStatement3(obj: Any?) {
       if (!(obj == 1)) {// 27 28
          if (obj is java.lang.Double) {// 29
-            System.out.println("Double");
+            System.out.println("Double")
          } else if (obj == null) {// 30
-            System.out.println("null");
+            System.out.println("null")
          } else if (obj !is java.lang.String && obj is Int) {// 31 32
-            System.out.println((obj as java.lang.Number).intValue() + 1);
+            System.out.println((obj as java.lang.Number).intValue() + 1)
          }
       }
    }// 35
 
    public fun testExpression(obj: Any): Int {
-      return if (obj == 1) 1 else (if (obj is java.lang.Double) 2 else (if (obj == "4") 4 else (if (obj !is java.lang.Long) 3 else 5)));// 38 39 40 41 42 43
+      return if (obj == 1) 1 else (if (obj is java.lang.Double) 2 else (if (obj == "4") 4 else (if (obj !is java.lang.Long) 3 else 5)))// 38 39 40 41 42 43
    }
 
    public fun testExpression2(obj: Any): Int {
       val text: java.lang.String = if (obj == 1)// 48 49
          "one"
          else
-         (if (obj is java.lang.Double) "double" else (if (obj == "4") "four" else (if (obj !is java.lang.Long) "not long" else "something")));// 50 51 52 53
-      System.out.println(text);// 55
-      return text.length();// 56
+         (if (obj is java.lang.Double) "double" else (if (obj == "4") "four" else (if (obj !is java.lang.Long) "not long" else "something")))// 50 51 52 53
+         System.out.println(text)// 55
+      return text.length()// 56
    }
 
    public fun testSwitchExpression(a: Int) {
-      var var10000: java.lang.String;
+      var var10000: java.lang.String
       when (a) {// 60
-         1 -> var10000 = "one";// 61
-         2, 3, 5 -> var10000 = "prime";// 62
-         4 -> var10000 = "something";// 63
-         else -> var10000 = "something";
+         1 -> var10000 = "one"// 61
+         2, 3, 5 -> var10000 = "prime"// 62
+         4 -> var10000 = "something"// 63
+         else -> var10000 = "something"
       }
 
-      System.out.println(var10000);// 65
+      System.out.println(var10000)// 65
    }// 66
 
    public fun testCompilesToTableSwitch(a: Int) {
       when (a) {// 69
-         1 -> System.out.println("The loneliest number");// 70
-         2, 3 -> System.out.println("Small prime");// 71
-         else -> System.out.println("Number");// 72
+         1 -> System.out.println("The loneliest number")// 70
+         2, 3 -> System.out.println("Small prime")// 71
+         else -> System.out.println("Number")// 72
       }
    }// 74
 
    public fun testCompilesToLookupSwitch(a: Int) {
       when (a) {// 77
-         1 -> System.out.println("Go for gold");// 78
-         9 -> System.out.println("The cat's meow");// 79
-         42 -> System.out.println("The answer");// 80
-         else -> System.out.println("Number");// 81
+         1 -> System.out.println("Go for gold")// 78
+         9 -> System.out.println("The cat's meow")// 79
+         42 -> System.out.println("The answer")// 80
+         else -> System.out.println("Number")// 81
       }
    }// 83
 
    public fun testSwitchWithEmptyCases(a: Int) {
       when (a) {// 86
          1 -> {}
-         2, 3 -> System.out.println(a + 4);// 88
-         4, 8, 1000 -> System.out.println("even");// 89
+         2, 3 -> System.out.println(a + 4)// 88
+         4, 8, 1000 -> System.out.println("even")// 89
          else -> {}
       }
    }// 92
 
    public fun testNoBranches(a: Any): Int {
-      return 0;// 95 96
+      return 0// 95 96
    }
 
    public fun booleanNightmares(a: Boolean, b: Boolean, c: Boolean, d: Boolean, e: Boolean, f: Boolean, g: Boolean) {
       if (a == (b != c)) {// 101 102
-         System.out.println("-_-");
+         System.out.println("-_-")
       } else if (a == (b && !e)) {// 103
-         System.out.println("xxx");
+         System.out.println("xxx")
       } else if (a == (!a || d)) {// 104
-         System.out.println("ohno");
+         System.out.println("ohno")
       } else if (!a) {// 105
-         System.out.println("NIGHTMARE");
+         System.out.println("NIGHTMARE")
       } else if (a == (g || e && f != c)) {// 106
-         System.out.println("hello");
+         System.out.println("hello")
       } else {
-         System.out.println("else");// 107
+         System.out.println("else")// 107
       }
    }// 109
 }

--- a/plugins/kotlin/testData/results/pkg/TestWhenBoolean.dec
+++ b/plugins/kotlin/testData/results/pkg/TestWhenBoolean.dec
@@ -9,7 +9,7 @@ public class TestWhenBoolean {
                a > b// 9
                   || (a > c || c > b) && (if (d == 7) b == 100 - a else a != -100 || b == 0 || c != 55 && (if (d == 66) 25 <= c && c < 34 else c < d && a < b))// 10 11 12 13 14 15 16
             )) {
-         System.out.println("hello");// 21
+         System.out.println("hello")// 21
       }
    }// 23
 }

--- a/plugins/kotlin/testData/results/pkg/TestWhenControlFlow.dec
+++ b/plugins/kotlin/testData/results/pkg/TestWhenControlFlow.dec
@@ -2,7 +2,7 @@ package pkg
 
 public class TestWhenControlFlow {
    public fun test1(x: Int) {
-      val xx: Int = x;// 5
+      val xx: Int = x// 5
 
       while (xx > 0) {// 7
          if (--xx == 10) {// 8 9 10
@@ -11,10 +11,10 @@ public class TestWhenControlFlow {
 
          if (xx != 5) {// 11
             if (3 <= xx && xx < 5) {// 12
-               return;
+               return
             }
 
-            System.out.println(xx);// 15
+            System.out.println(xx)// 15
          }
       }
    }// 17

--- a/src/org/jetbrains/java/decompiler/api/plugin/StatementWriter.java
+++ b/src/org/jetbrains/java/decompiler/api/plugin/StatementWriter.java
@@ -3,6 +3,7 @@ package org.jetbrains.java.decompiler.api.plugin;
 import org.jetbrains.java.decompiler.main.ClassesProcessor;
 import org.jetbrains.java.decompiler.main.collectors.ImportCollector;
 import org.jetbrains.java.decompiler.main.rels.ClassWrapper;
+import org.jetbrains.java.decompiler.modules.decompiler.exps.Exprent;
 import org.jetbrains.java.decompiler.struct.StructClass;
 import org.jetbrains.java.decompiler.struct.StructField;
 import org.jetbrains.java.decompiler.struct.StructMethod;
@@ -16,4 +17,6 @@ public interface StatementWriter {
   void writeField(ClassWrapper wrapper, StructClass cl, StructField fd, TextBuffer buffer, int indent);
 
   boolean writeMethod(ClassesProcessor.ClassNode node, StructMethod mt, int methodIndex, TextBuffer buffer, int indent);
+  
+  boolean endsWithSemicolon(Exprent expr);
 }

--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -63,6 +63,13 @@ public class ClassWriter implements StatementWriter {
     javadocProvider = (IFabricJavadocProvider) DecompilerContext.getProperty(IFabricJavadocProvider.PROPERTY_NAME);
   }
 
+  public boolean endsWithSemicolon(Exprent expr) {
+    return !(expr instanceof SwitchHeadExprent ||
+      expr instanceof MonitorExprent ||
+      expr instanceof IfExprent ||
+      (expr instanceof VarExprent && ((VarExprent)expr).isClassDef()));
+  }
+
   private static boolean invokeProcessors(TextBuffer buffer, ClassNode node) {
     ClassWrapper wrapper = node.getWrapper();
     if (wrapper == null) {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
@@ -1,12 +1,16 @@
 // Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.jetbrains.java.decompiler.modules.decompiler;
 
+import org.jetbrains.java.decompiler.api.Decompiler;
+import org.jetbrains.java.decompiler.api.plugin.LanguageSpec;
+import org.jetbrains.java.decompiler.api.plugin.StatementWriter;
 import org.jetbrains.java.decompiler.code.CodeConstants;
 import org.jetbrains.java.decompiler.code.Instruction;
 import org.jetbrains.java.decompiler.code.InstructionSequence;
 import org.jetbrains.java.decompiler.code.cfg.BasicBlock;
 import org.jetbrains.java.decompiler.main.DecompilerContext;
 import org.jetbrains.java.decompiler.main.collectors.ImportCollector;
+import org.jetbrains.java.decompiler.main.plugins.PluginContext;
 import org.jetbrains.java.decompiler.modules.decompiler.flow.DirectEdgeType;
 import org.jetbrains.java.decompiler.struct.gen.CodeType;
 import org.jetbrains.java.decompiler.util.collections.ListStack;
@@ -877,6 +881,9 @@ public class ExprProcessor implements CodeConstants {
       return new TextBuffer();
     }
 
+    StructClass cl = DecompilerContext.getContextProperty(DecompilerContext.CURRENT_CLASS);
+    LanguageSpec spec = PluginContext.getCurrentContext().getLanguageSpec(cl);
+
     TextBuffer buf = new TextBuffer();
     lst = Exprent.sortIndexed(lst);
 
@@ -898,8 +905,14 @@ public class ExprProcessor implements CodeConstants {
         if (expr instanceof MonitorExprent && ((MonitorExprent)expr).getMonType() == MonitorExprent.Type.ENTER) {
           buf.append("{} // $VF: monitorenter "); // empty synchronized block
         }
-        if (endsWithSemicolon(expr)) {
-          buf.append(";");
+        if (spec != null) {
+          if (spec.writer.endsWithSemicolon(expr)) {
+            buf.append(';');
+          }
+        } else {
+          if (endsWithSemicolon(expr)) {
+            buf.append(';');
+          }
         }
         buf.appendLineSeparator();
       }


### PR DESCRIPTION
This also makes a small change to [KotlinChooser](https://github.com/Vineflower/vineflower/blob/feature/semicolon-delegate/plugins/kotlin/src/main/java/org/vineflower/kotlin/KotlinChooser.java) to reduce the cost of `PluginContext.getLanguageSpec` calls by a significant amount