### PR TITLE
Fix plugins not loading when a ZipFS has already been opened for the current Jar

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/plugins/JarPluginLoader.java
+++ b/src/org/jetbrains/java/decompiler/main/plugins/JarPluginLoader.java
@@ -13,15 +13,11 @@ public class JarPluginLoader {
 
   public static void init() {
     try {
-      File myFile = new File(JarPluginLoader.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+      Path myFile = Paths.get(JarPluginLoader.class.getProtectionDomain().getCodeSource().getLocation().toURI());
 
       // Ensure we are running out of a file
-      if (myFile.exists() && !myFile.isDirectory() && myFile.getPath().endsWith(".jar")) {
-        URI uri = URI.create("jar:" + myFile.toURI());
-
-        Map<String, String> env = new HashMap<>();
-
-        FileSystem zipfs = FileSystems.newFileSystem(uri, env);
+      if (Files.isRegularFile(myFile) && myFile.getFileName().toString().endsWith(".jar")) {
+        FileSystem zipfs = FileSystems.newFileSystem(myFile, (ClassLoader) null);
 
         Path pluginsDir = zipfs.getPath("META-INF", "plugins");
         if (!Files.exists(pluginsDir)) {


### PR DESCRIPTION
When VF is embedded in a Shadow Jar and that Shadow Jar is previously opened as a ZipFS, then this may happen when the plugins are initialized:

```java
java.nio.file.FileSystemAlreadyExistsException
        at jdk.zipfs/jdk.nio.zipfs.ZipFileSystemProvider.newFileSystem(ZipFileSystemProvider.java:104)
        at java.base/java.nio.file.FileSystems.newFileSystem(FileSystems.java:339)
        at java.base/java.nio.file.FileSystems.newFileSystem(FileSystems.java:288)
        at org.jetbrains.java.decompiler.main.plugins.JarPluginLoader.init(JarPluginLoader.java:24)
        at org.jetbrains.java.decompiler.main.Init.init(Init.java:19)
        at org.jetbrains.java.decompiler.main.Fernflower.<clinit>(Fernflower.java:228)
        at org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler.<init>(ConsoleDecompiler.java:225)
        at org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler.main(ConsoleDecompiler.java:178)
        at net.neoforged.snowblower.Generator.getDecompiledJar(Generator.java:711)
        at net.neoforged.snowblower.Generator.generate(Generator.java:532)
        at net.neoforged.snowblower.Generator.runInternal(Generator.java:365)
        at net.neoforged.snowblower.Generator.run(Generator.java:234)
        at net.neoforged.snowblower.Main.main(Main.java:130)
```

This PR aims to fix that by avoiding opening a URI based FS and instead tries to only use Path based FS.