### PR TITLE
Fix exception desync

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/deobfuscator/ExceptionDeobfuscator.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/deobfuscator/ExceptionDeobfuscator.java
@@ -439,6 +439,8 @@ public final class ExceptionDeobfuscator {
 
           for (BasicBlock succ : handler.getSuccExceptions()) {
             newBlock.addSuccessorException(succ);
+            var excRange = graph.getExceptionRange(succ, handler);
+            excRange.getProtectedRange().add(newBlock);
           }
         }
 


### PR DESCRIPTION
Finally made a PR for this fix. AFAIK (almost) any input that would trigger this still fails to decompile.

The bug in question: when an exception handler is duplicated as a deobfuscation step, and the handler was inside another exception region, it did not have that fact properly copied over.