### PR TITLE
Fix accidental generic erasure in method bodies

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -1180,6 +1180,13 @@ public class ClassWriter implements StatementWriter {
 
         ClassNode currentNode = node;
         while (currentNode != null) {
+          if (currentNode.enclosingMethod != null) {
+            StructMethod enclosingMethod = currentNode.parent.classStruct.getMethod(currentNode.enclosingMethod);
+            if (enclosingMethod != null && enclosingMethod.getSignature() != null) {
+              checker = checker.copy(enclosingMethod.getSignature().typeParameters, enclosingMethod.getSignature().typeParameterBounds);
+            }
+          }
+
           GenericClassDescriptor parentSignature = currentNode.classStruct.getSignature();
           if (parentSignature != null) {
             checker = checker.copy(parentSignature.getChecker());

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -730,6 +730,8 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_17, "TestSwitchOnEnumFake");
     register(JAVA_16, "TestSwitchExpressionReturnType");
     register(JAVA_8, "TestGenericMapping");
+    register(JAVA_8, "TestNestedGenerics1");
+    register(JAVA_11, "TestNestedGenerics2");
 
     registerRaw(CUSTOM, "TestCorruptedSignatures").setExpectedFileName("Signatures.java");
   }

--- a/testData/results/pkg/TestNestedGenerics1.dec
+++ b/testData/results/pkg/TestNestedGenerics1.dec
@@ -1,0 +1,40 @@
+package pkg;
+
+import java.util.function.Function;
+
+public class TestNestedGenerics1 {
+   public static <T, R> R test(T t) {
+      Function<T, R> instance = new Function<T, R>() {// 7
+         public R apply(T t) {
+            return null;// 10
+         }
+      };
+      return (R)instance.apply(t);// 13
+   }
+}
+
+class 'pkg/TestNestedGenerics1' {
+   method 'test (Ljava/lang/Object;)Ljava/lang/Object;' {
+      7      6
+      8      11
+      9      11
+      a      11
+      b      11
+      c      11
+      d      11
+      e      11
+      f      11
+   }
+}
+
+class 'pkg/TestNestedGenerics1$1' {
+   method 'apply (Ljava/lang/Object;)Ljava/lang/Object;' {
+      0      8
+      1      8
+   }
+}
+
+Lines mapping:
+7 <-> 7
+10 <-> 9
+13 <-> 12

--- a/testData/results/pkg/TestNestedGenerics2.dec
+++ b/testData/results/pkg/TestNestedGenerics2.dec
@@ -1,0 +1,36 @@
+package pkg;
+
+public class TestNestedGenerics2 {
+   public static <T, R> R test(T t) {
+      var instance = new Object() {// 5
+         R run(T t) {
+            return null;// 7
+         }
+      };
+      return (R)instance.run(t);// 10
+   }
+}
+
+class 'pkg/TestNestedGenerics2' {
+   method 'test (Ljava/lang/Object;)Ljava/lang/Object;' {
+      7      4
+      8      9
+      9      9
+      a      9
+      b      9
+      c      9
+      d      9
+   }
+}
+
+class 'pkg/TestNestedGenerics2$1' {
+   method 'run (Ljava/lang/Object;)Ljava/lang/Object;' {
+      0      6
+      1      6
+   }
+}
+
+Lines mapping:
+5 <-> 5
+7 <-> 7
+10 <-> 10

--- a/testData/src/java11/pkg/TestNestedGenerics2.java
+++ b/testData/src/java11/pkg/TestNestedGenerics2.java
@@ -1,0 +1,12 @@
+package pkg;
+
+public class TestNestedGenerics2 {
+  public static <T, R> R test(T t) {
+    var instance = new Object() {
+      R run(T t) {
+        return null;
+      }
+    };
+    return instance.run(t);
+  }
+}

--- a/testData/src/java8/pkg/TestNestedGenerics1.java
+++ b/testData/src/java8/pkg/TestNestedGenerics1.java
@@ -1,0 +1,15 @@
+package pkg;
+
+import java.util.function.Function;
+
+public class TestNestedGenerics1 {
+  public static <T, R> R test(T t) {
+    Function<T, R> instance = new Function<T, R>() {
+      @Override
+      public R apply(T t) {
+        return null;
+      }
+    };
+    return instance.apply(t);
+  }
+}


### PR DESCRIPTION
Fixes an issue caused by [my generics checker](https://github.com/Vineflower/vineflower/commit/a64ce58f5cab75fb4594b1e1ce216231bc3e6ffc) involving generics within anonymous classes (and possibly lambdas). Also adds tests involving anonymous classes.