### PR TITLE
Fix decomp test failures caused by try/catch type changes

### DIFF
--- a/plugins/kotlin/src/main/java/org/vineflower/kotlin/pass/ReplaceStatsPass.java
+++ b/plugins/kotlin/src/main/java/org/vineflower/kotlin/pass/ReplaceStatsPass.java
@@ -29,6 +29,9 @@ public class ReplaceStatsPass implements Pass {
       } else if (st instanceof IfStatement) {
         st.replaceWith(new KIfStatement((IfStatement) st));
         res = true;
+      } else if (st instanceof CatchStatement) {
+        st.replaceWith(new KCatchStatement((CatchStatement) st));
+        res = true;
       }
     }
 

--- a/plugins/kotlin/src/main/java/org/vineflower/kotlin/stat/KCatchStatement.java
+++ b/plugins/kotlin/src/main/java/org/vineflower/kotlin/stat/KCatchStatement.java
@@ -1,0 +1,84 @@
+package org.vineflower.kotlin.stat;
+
+import org.jetbrains.java.decompiler.code.CodeConstants;
+import org.jetbrains.java.decompiler.code.cfg.BasicBlock;
+import org.jetbrains.java.decompiler.modules.decompiler.ExprProcessor;
+import org.jetbrains.java.decompiler.modules.decompiler.ValidationHelper;
+import org.jetbrains.java.decompiler.modules.decompiler.exps.Exprent;
+import org.jetbrains.java.decompiler.modules.decompiler.exps.VarExprent;
+import org.jetbrains.java.decompiler.modules.decompiler.stats.CatchStatement;
+import org.jetbrains.java.decompiler.modules.decompiler.stats.Statement;
+import org.jetbrains.java.decompiler.struct.gen.CodeType;
+import org.jetbrains.java.decompiler.struct.gen.VarType;
+import org.jetbrains.java.decompiler.util.TextBuffer;
+
+import java.util.List;
+
+public class KCatchStatement extends CatchStatement {
+  public KCatchStatement(CatchStatement statement) {
+    super();
+    getExctStrings().addAll(statement.getExctStrings());
+    getVars().addAll(statement.getVars());
+    getResources().addAll(statement.getResources());
+
+    setFirst(statement.getFirst());
+    stats.addAllWithKey(statement.getStats(), statement.getStats().getLstKeys());
+    parent = statement.getParent();
+    first = statement.getFirst();
+    exprents = statement.getExprents();
+    labelEdges.addAll(statement.getLabelEdges());
+    varDefinitions.addAll(statement.getVarDefinitions());
+    post = statement.getPost();
+    lastBasicType = statement.getLastBasicType();
+
+    isMonitorEnter = statement.isMonitorEnter();
+    containsMonitorExit = statement.containsMonitorExit();
+    isLastAthrow = statement.containsMonitorExitOrAthrow() && !containsMonitorExit;
+
+    continueSet = statement.getContinueSet();
+  }
+
+  @Override
+  public TextBuffer toJava(int indent) {
+    TextBuffer buf = new TextBuffer();
+    buf.append(ExprProcessor.listToJava(varDefinitions, indent));
+
+    if (isLabeled()) {
+      buf.appendIndent(indent).append("label").append(id).append("@ ");
+    }
+
+    buf.appendIndent(indent++).append("try {").appendLineSeparator();
+
+    for (Exprent resource : getResources()) {
+      buf.append(indent++).append(resource.toJava(indent)).append(".use {").appendLineSeparator();
+    }
+
+    buf.append(ExprProcessor.jmpWrapper(first, indent, false));
+
+    buf.appendIndent(--indent).append("}");
+    for (Exprent ignored : getResources()) {
+      buf.appendLineSeparator();
+      buf.appendIndent(--indent).append("}");
+    }
+
+    for (int i = 1; i < stats.size(); i++) {
+      Statement stat = stats.get(i);
+
+      BasicBlock block = stat.getBasichead().getBlock();
+      if (!block.getSeq().isEmpty() && block.getInstruction(0).opcode == CodeConstants.opc_astore) {
+        Integer offset = block.getOldOffset(0);
+        if (offset > -1) buf.addBytecodeMapping(offset);
+      }
+
+      buf.append(" catch (");
+      buf.append(getVars().get(i - 1).toJava(indent));
+      buf.append(") {").appendLineSeparator();
+      buf.append(stat.toJava(indent + 1));
+      buf.appendIndent(indent).append("}");
+    }
+
+    buf.appendLineSeparator();
+
+    return buf;
+  }
+}

--- a/plugins/kotlin/testData/results/pkg/TestTailrecFunctions.dec
+++ b/plugins/kotlin/testData/results/pkg/TestTailrecFunctions.dec
@@ -45,12 +45,12 @@ public class TestTailrecFunctions {
    }// 31
 
    public tailrec fun testTryCatchFinally() {
-      run label34@{
-         run label33@{
+      run label35@{
+         run label34@{
             try {
                try {
                   this.testTryCatchFinally()// 35
-                  break label33;
+                  break label34;
                } catch (var2: Exception) {// 36
                   this.testTryCatchFinally()// 37
                }

--- a/plugins/kotlin/testData/results/pkg/TestTryFinallyExpressions.dec
+++ b/plugins/kotlin/testData/results/pkg/TestTryFinallyExpressions.dec
@@ -40,21 +40,21 @@ public class TestTryFinallyExpressions {
    }
 
    public fun test2(a: String, b: String) {
-      run label140@{
+      run label141@{
          var var19: java.lang.String = a// 28
 
-         run label139@{
-            run label138@{
-               run label137@{
+         run label140@{
+            run label139@{
+               run label138@{
                   try {
                      try {
                         if (a == b) {// 30
-                           return@label139
+                           return@label140
                         }
 
                         var19 = b// 33
                         this.test0(b)// 34
-                        return@label137
+                        return@label138
                      } catch (var11: IOException) {// 36
                         var19 = a// 37
                         this.test1(a, a)// 38
@@ -65,7 +65,7 @@ public class TestTryFinallyExpressions {
                   }
 
                   var19 = if (var19 == a) b else a
-                  return@label138// 46
+                  return@label139// 46
                }
 
                var19 = if (var19 == a) b else a


### PR DESCRIPTION
In Kotlin 2.4 and beyond, this may need revisiting because of the addition of [rich errors](https://resources.jetbrains.com/storage/products/kotlinconf-2025/may-22/Rich%20Errors%20in%20Kotlin%20_%20Michail%20Zarec%CC%8Censkij.pdf)