### PR TITLE
Prefix counter to exported dot files, so they appear in chronological order

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/collectors/CounterContainer.java
+++ b/src/org/jetbrains/java/decompiler/main/collectors/CounterContainer.java
@@ -5,8 +5,9 @@ public class CounterContainer {
   public static final int STATEMENT_COUNTER = 0;
   public static final int EXPRESSION_COUNTER = 1;
   public static final int VAR_COUNTER = 2;
+  public static final int DOT_FILE_COUNTER = 3;
 
-  private final int[] values = new int[]{1, 1, 1};
+  private final int[] values = new int[]{1, 1, 1, 1};
 
   public void setCounter(int counter, int value) {
     values[counter] = value;

--- a/src/org/jetbrains/java/decompiler/util/DotExporter.java
+++ b/src/org/jetbrains/java/decompiler/util/DotExporter.java
@@ -35,6 +35,9 @@ public class DotExporter {
   private static final boolean EXTENDED_MODE = false;
   private static final boolean STATEMENT_LR_MODE = false;
   private static final boolean SAME_RANK_MODE = false;
+
+  private static final Map<String, Integer> counter = new HashMap<>();
+
   // https://dreampuf.github.io/GraphvizOnline/ is a nice visualizer for the outputed dots.
 
   // Outputs a statement and as much of its information as possible into a dot formatted string.
@@ -690,7 +693,10 @@ public class DotExporter {
       root.mkdirs();
     }
 
+    int count = counter.merge(InterpreterUtil.makeUniqueKey(mt.getName(), mt.getDescriptor()), 1, Integer::sum);
+
     return new File(root,
+      count + "_" +
       mt.getName().replace('<', '.').replace('>', '_') +
         mt.getDescriptor().replace('/', '.') +
         '_' + suffix + ".dot");

--- a/src/org/jetbrains/java/decompiler/util/DotExporter.java
+++ b/src/org/jetbrains/java/decompiler/util/DotExporter.java
@@ -4,6 +4,7 @@ import org.jetbrains.java.decompiler.code.cfg.BasicBlock;
 import org.jetbrains.java.decompiler.code.cfg.ControlFlowGraph;
 import org.jetbrains.java.decompiler.code.cfg.ExceptionRangeCFG;
 import org.jetbrains.java.decompiler.main.DecompilerContext;
+import org.jetbrains.java.decompiler.main.collectors.CounterContainer;
 import org.jetbrains.java.decompiler.main.rels.DecompileRecord;
 import org.jetbrains.java.decompiler.modules.decompiler.ExprProcessor;
 import org.jetbrains.java.decompiler.modules.decompiler.StatEdge;
@@ -35,8 +36,6 @@ public class DotExporter {
   private static final boolean EXTENDED_MODE = false;
   private static final boolean STATEMENT_LR_MODE = false;
   private static final boolean SAME_RANK_MODE = false;
-
-  private static final Map<String, Integer> counter = new HashMap<>();
 
   // https://dreampuf.github.io/GraphvizOnline/ is a nice visualizer for the outputed dots.
 
@@ -693,7 +692,7 @@ public class DotExporter {
       root.mkdirs();
     }
 
-    int count = counter.merge(InterpreterUtil.makeUniqueKey(mt.getName(), mt.getDescriptor()), 1, Integer::sum);
+    int count = DecompilerContext.getCounterContainer().getCounterAndIncrement(CounterContainer.DOT_FILE_COUNTER);
 
     return new File(root,
       count + "_" +


### PR DESCRIPTION
<img width="318" height="931" alt="image" src="https://github.com/user-attachments/assets/c3993028-77f2-4aa1-80cb-385ed5ecdfe0" />
