### PR TITLE
Convert lambdas to method references when javac compiles a method reference to a lambda

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessor.java
+++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessor.java
@@ -346,6 +346,11 @@ public class MethodProcessor implements Runnable {
         continue;
       }
 
+      if (MethodReferenceHelper.convertToMethodReference(root)) {
+        decompileRecord.add("ProcessLambda", root);
+        continue;
+      }
+
       if (InlineSingleBlockHelper.inlineSingleBlocks(root)) {
         decompileRecord.add("InlineSingleBlocks", root);
         continue;

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/MethodReferenceHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/MethodReferenceHelper.java
@@ -1,0 +1,266 @@
+package org.jetbrains.java.decompiler.modules.decompiler;
+
+import org.jetbrains.java.decompiler.code.CodeConstants;
+import org.jetbrains.java.decompiler.code.FullInstructionSequence;
+import org.jetbrains.java.decompiler.code.Instruction;
+import org.jetbrains.java.decompiler.main.ClassesProcessor;
+import org.jetbrains.java.decompiler.main.ClassesProcessor.ClassNode;
+import org.jetbrains.java.decompiler.main.ClassesProcessor.ClassNode.LambdaInformation;
+import org.jetbrains.java.decompiler.main.DecompilerContext;
+import org.jetbrains.java.decompiler.modules.decompiler.exps.*;
+import org.jetbrains.java.decompiler.modules.decompiler.stats.RootStatement;
+import org.jetbrains.java.decompiler.modules.decompiler.stats.Statement;
+import org.jetbrains.java.decompiler.struct.StructClass;
+import org.jetbrains.java.decompiler.struct.StructMethod;
+import org.jetbrains.java.decompiler.struct.consts.LinkConstant;
+import org.jetbrains.java.decompiler.util.InterpreterUtil;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+public class MethodReferenceHelper {
+  public static boolean convertToMethodReference(RootStatement root) throws IOException {
+    return convertToMethodReferenceRec(root);
+  }
+
+  public static boolean convertToMethodReferenceRec(Statement stat) throws IOException {
+    boolean result = false;
+    for (Statement subStat : stat.getStats()) {
+      result |= convertToMethodReferenceRec(subStat);
+    }
+    if (stat.getExprents() != null) {
+      for (int i = 0; i < stat.getExprents().size(); i++) {
+        Exprent exp = stat.getExprents().get(i);
+        for (Exprent subExp : exp.getAllExprents(true)) {
+          if (convertToMethodReference(stat, i, subExp)) {
+            result |= true;
+          }
+          for (int j = 0; j < stat.getExprents().size(); j++) {
+            if (stat.getExprents().get(j) == exp) {
+              i = j;
+              break;
+            }
+          }
+          if (removeInstanceAssignment(stat, i, subExp)) {
+            result |= true;
+          }
+          for (int j = 0; j < stat.getExprents().size(); j++) {
+            if (stat.getExprents().get(j) == exp) {
+              i = j;
+              break;
+            }
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  private static boolean convertToMethodReference(Statement stat, int i, Exprent exp) throws IOException {
+    if (exp instanceof NewExprent newExprent
+        && newExprent.isLambda()
+        && !newExprent.isMethodReference()) {
+      if (stat.getTopParent().mt.getName().contains("<init>")) {
+        System.out.println();
+      }
+      String className = newExprent.getNewType().value;
+      ClassNode node = DecompilerContext.getClassProcessor().getMapRootClasses().get(className);
+      LambdaInformation info = node.lambdaInformation;
+      StructClass struct = DecompilerContext.getStructContext().getClass(info.content_class_name);
+      StructMethod method = struct.getMethod(info.content_method_key);
+      if (!method.hasModifier(CodeConstants.ACC_STATIC))
+        return false;
+      method.expandData(struct);
+      FullInstructionSequence seq = method.getInstructionSequence();
+      Iterator<Instruction> iterator = seq.iterator();
+      Instruction next = null;
+      int argument = 0;
+
+      if (!iterator.hasNext())
+        return false;
+      next = iterator.next();
+
+      // new instance
+      if (next.opcode == CodeConstants.opc_new) {
+        if (!iterator.hasNext())
+          return false;
+        next = iterator.next();
+        if (next.opcode != CodeConstants.opc_dup)
+          return false;
+
+        if (!iterator.hasNext())
+          return false;
+        next = iterator.next();
+      }
+
+      // Load arguments
+      while (iterator.hasNext()
+          && next.opcode >= CodeConstants.opc_iload && next.opcode <= CodeConstants.opc_aload
+          && next.operand(0) == argument) {
+        next = iterator.next();
+        argument++;
+      }
+
+      if (next == null)
+        return false;
+      boolean varargs = false;
+      int varargsCount = 0;
+      // varargs array length
+      if (next.opcode >= CodeConstants.opc_bipush && next.opcode <= CodeConstants.opc_sipush) {
+        varargsCount = next.operand(0);
+        varargs = true;
+
+        // varargs array creation
+        if (!iterator.hasNext())
+          return false;
+        next = iterator.next();
+        if (next.opcode < CodeConstants.opc_newarray || next.opcode > CodeConstants.opc_anewarray)
+          return false;
+        for (int j = 0; j < varargsCount; j++) {
+
+          // duplicate varargs array
+          if (!iterator.hasNext())
+            return false;
+          next = iterator.next();
+          if (next.opcode != CodeConstants.opc_dup)
+            return false;
+
+          // varargs array index
+          if (!iterator.hasNext())
+            return false;
+          next = iterator.next();
+          if (next.opcode < CodeConstants.opc_bipush || next.opcode > CodeConstants.opc_sipush
+              || next.operand(0) != j)
+            return false;
+
+          // load argument for varargs array
+          if (!iterator.hasNext())
+            return false;
+          next = iterator.next();
+          if (next.opcode < CodeConstants.opc_iload || next.opcode > CodeConstants.opc_aload
+              || next.operand(0) != argument + j)
+            return false;
+
+          // store argument in varargs array
+          if (!iterator.hasNext())
+            return false;
+          next = iterator.next();
+          if (next.opcode < CodeConstants.opc_iastore || next.opcode > CodeConstants.opc_sastore)
+            return false;
+        }
+
+        if (!iterator.hasNext())
+          return false;
+        next = iterator.next();
+      }
+      // invoke method
+      if (next.opcode < CodeConstants.opc_invokevirtual || next.opcode > CodeConstants.opc_invokeinterface)
+        return false;
+
+      Instruction invoke = next;
+
+      if (!iterator.hasNext())
+        return false;
+      next = iterator.next();
+
+      if (next.opcode == CodeConstants.opc_pop) {
+        if (!iterator.hasNext())
+          return false;
+        next = iterator.next();
+      }
+
+      // return
+      if (next.opcode < CodeConstants.opc_ireturn || next.opcode > CodeConstants.opc_return)
+        return false;
+
+      if (iterator.hasNext())
+        return false;
+
+      LinkConstant link = struct.getPool().getLinkConstant(invoke.operand(0));
+      boolean instance = invoke.opcode != CodeConstants.opc_invokestatic
+          && !link.elementname.equals(CodeConstants.INIT_NAME);
+
+      String newClass = link.classname;
+      String newMethod = link.elementname;
+      String newDescriptor = link.descriptor;
+      String newKey = InterpreterUtil.makeUniqueKey(newMethod, newDescriptor);
+
+      StructClass newStructClass = DecompilerContext.getStructContext().getClass(newClass);
+      if (newStructClass == null)
+        return false;
+      StructMethod newStructMethod = newStructClass.getMethodRecursive(newMethod, newDescriptor);
+      if (newStructMethod == null)
+        return false;
+
+      if (newStructMethod.hasModifier(CodeConstants.ACC_SYNTHETIC))
+        return false;
+
+      ClassNode newNode = DecompilerContext.getClassProcessor().getMapRootClasses().get(newClass);
+      if (newNode != null && newNode.type == ClassesProcessor.ClassNode.Type.ANONYMOUS)
+        return false;
+
+      if (method.methodDescriptor().params.length - (varargs ? varargsCount - 1 : 0) != newStructMethod.methodDescriptor().params.length + (instance ? 1 : 0))
+        return false;
+      if (newExprent.getConstructor().getLstParameters().size() > (instance ? 1 : 0))
+        return false;
+      info.content_class_name = newClass;
+      info.content_method_name = newMethod;
+      info.content_method_descriptor = newDescriptor;
+      info.content_method_invocation_type = switch (invoke.opcode) {
+        case CodeConstants.opc_invokevirtual -> CodeConstants.CONSTANT_MethodHandle_REF_invokeVirtual;
+        case CodeConstants.opc_invokespecial -> instance ? CodeConstants.CONSTANT_MethodHandle_REF_newInvokeSpecial : CodeConstants.CONSTANT_MethodHandle_REF_invokeSpecial;
+        case CodeConstants.opc_invokestatic -> CodeConstants.CONSTANT_MethodHandle_REF_invokeStatic;
+        case CodeConstants.opc_invokeinterface -> CodeConstants.CONSTANT_MethodHandle_REF_invokeInterface;
+        default -> -1;
+      };
+      info.content_method_key = newKey;
+      info.is_method_reference = true;
+      info.is_content_method_static = invoke.opcode == CodeConstants.opc_invokestatic;
+      newExprent.setMethodReference(true);
+      InvocationExprent constructor = newExprent.getConstructor();
+      if (instance && constructor.getLstParameters().size() == 1) {
+        constructor.setInstance(constructor.getLstParameters().get(0));
+      }
+
+      if (i > 0) {
+        Exprent instanceExp = newExprent.getConstructor().getInstance();
+        Exprent previous = stat.getExprents().get(i - 1);
+        if (instanceExp instanceof VarExprent varExp
+            && previous instanceof AssignmentExprent assignment
+            && varExp.equalsVersions(assignment.getLeft())
+            && !varExp.isVarReferenced(stat.getTopParent(), (VarExprent) assignment.getLeft())) {
+          newExprent.getConstructor().setInstance(assignment.getRight());
+          newExprent.getConstructor().getLstParameters().set(0, assignment.getRight());
+          stat.getExprents().remove(i - 1);
+        }
+      }
+      return true;
+    }
+    return false;
+  }
+
+  private static boolean removeInstanceAssignment(Statement stat, int i, Exprent exp) {
+    if (exp instanceof NewExprent newExp
+        && newExp.isLambda()
+        && newExp.isMethodReference()
+        && i >= 2
+        && newExp.getConstructor().getInstance() instanceof VarExprent stackVar
+        && stackVar.isStack()) {
+        Exprent nonNull = stat.getExprents().get(i - 1);
+        Exprent assign = stat.getExprents().get(i - 2);
+        if (nonNull instanceof InvocationExprent inv
+            && inv.getClassname().equals("java/util/Objects")
+            && inv.getName().equals("requireNonNull")
+            && inv.getStringDescriptor().equals("(Ljava/lang/Object;)Ljava/lang/Object;")
+            && stackVar.equalsVersions(inv.getLstParameters().get(0))
+            && assign instanceof AssignmentExprent stackAssign
+            && stackVar.equalsVersions(stackAssign.getLeft())) {
+          newExp.getConstructor().setInstance(stackAssign.getRight());
+          stat.getExprents().remove(i - 1);
+          stat.getExprents().remove(i - 2);
+          return true;
+        }
+      }
+    return false;
+  }
+}

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/MethodReferenceHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/MethodReferenceHelper.java
@@ -256,6 +256,7 @@ public class MethodReferenceHelper {
             && assign instanceof AssignmentExprent stackAssign
             && stackVar.equalsVersions(stackAssign.getLeft())) {
           newExp.getConstructor().setInstance(stackAssign.getRight());
+          newExp.getConstructor().getLstParameters().set(0, stackAssign.getRight());
           stat.getExprents().remove(i - 1);
           stat.getExprents().remove(i - 2);
           return true;

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/MethodReferenceHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/MethodReferenceHelper.java
@@ -57,186 +57,179 @@ public class MethodReferenceHelper {
   }
 
   private static boolean convertToMethodReference(Statement stat, int i, Exprent exp) throws IOException {
-    if (exp instanceof NewExprent newExprent
-        && newExprent.isLambda()
-        && !newExprent.isMethodReference()) {
-      if (stat.getTopParent().mt.getName().contains("<init>")) {
-        System.out.println();
-      }
-      String className = newExprent.getNewType().value;
-      ClassNode node = DecompilerContext.getClassProcessor().getMapRootClasses().get(className);
-      LambdaInformation info = node.lambdaInformation;
-      StructClass struct = DecompilerContext.getStructContext().getClass(info.content_class_name);
-      StructMethod method = struct.getMethod(info.content_method_key);
-      if (!method.hasModifier(CodeConstants.ACC_STATIC))
+    if (!(exp instanceof NewExprent newExprent)
+        || !newExprent.isLambda()
+        || newExprent.isMethodReference())
+      return false;
+    String className = newExprent.getNewType().value;
+    ClassNode node = DecompilerContext.getClassProcessor().getMapRootClasses().get(className);
+    LambdaInformation info = node.lambdaInformation;
+    StructClass struct = DecompilerContext.getStructContext().getClass(info.content_class_name);
+    StructMethod method = struct.getMethod(info.content_method_key);
+    if (!method.hasModifier(CodeConstants.ACC_STATIC))
+      return false;
+    method.expandData(struct);
+    FullInstructionSequence seq = method.getInstructionSequence();
+    Iterator<Instruction> iterator = seq.iterator();
+    int argument = 0;
+
+    if (!iterator.hasNext())
+      return false;
+    Instruction next = iterator.next();
+
+    // new instance
+    if (next.opcode == CodeConstants.opc_new) {
+      if (!iterator.hasNext())
         return false;
-      method.expandData(struct);
-      FullInstructionSequence seq = method.getInstructionSequence();
-      Iterator<Instruction> iterator = seq.iterator();
-      Instruction next = null;
-      int argument = 0;
+      next = iterator.next();
+      if (next.opcode != CodeConstants.opc_dup)
+        return false;
 
       if (!iterator.hasNext())
         return false;
       next = iterator.next();
+    }
 
-      // new instance
-      if (next.opcode == CodeConstants.opc_new) {
+    // Load arguments
+    while (iterator.hasNext()
+        && next.opcode >= CodeConstants.opc_iload && next.opcode <= CodeConstants.opc_aload
+        && next.operand(0) == argument) {
+      next = iterator.next();
+      argument++;
+    }
+
+    boolean varargs = false;
+    int varargsCount = 0;
+    // varargs array length
+    if (next.opcode >= CodeConstants.opc_bipush && next.opcode <= CodeConstants.opc_sipush) {
+      varargsCount = next.operand(0);
+      varargs = true;
+
+      // varargs array creation
+      if (!iterator.hasNext())
+        return false;
+      next = iterator.next();
+      if (next.opcode < CodeConstants.opc_newarray || next.opcode > CodeConstants.opc_anewarray)
+        return false;
+      for (int j = 0; j < varargsCount; j++) {
+
+        // duplicate varargs array
         if (!iterator.hasNext())
           return false;
         next = iterator.next();
         if (next.opcode != CodeConstants.opc_dup)
           return false;
 
+        // varargs array index
         if (!iterator.hasNext())
           return false;
         next = iterator.next();
-      }
+        if (next.opcode < CodeConstants.opc_bipush || next.opcode > CodeConstants.opc_sipush
+            || next.operand(0) != j)
+          return false;
 
-      // Load arguments
-      while (iterator.hasNext()
-          && next.opcode >= CodeConstants.opc_iload && next.opcode <= CodeConstants.opc_aload
-          && next.operand(0) == argument) {
-        next = iterator.next();
-        argument++;
-      }
-
-      if (next == null)
-        return false;
-      boolean varargs = false;
-      int varargsCount = 0;
-      // varargs array length
-      if (next.opcode >= CodeConstants.opc_bipush && next.opcode <= CodeConstants.opc_sipush) {
-        varargsCount = next.operand(0);
-        varargs = true;
-
-        // varargs array creation
+        // load argument for varargs array
         if (!iterator.hasNext())
           return false;
         next = iterator.next();
-        if (next.opcode < CodeConstants.opc_newarray || next.opcode > CodeConstants.opc_anewarray)
+        if (next.opcode < CodeConstants.opc_iload || next.opcode > CodeConstants.opc_aload
+            || next.operand(0) != argument + j)
           return false;
-        for (int j = 0; j < varargsCount; j++) {
 
-          // duplicate varargs array
-          if (!iterator.hasNext())
-            return false;
-          next = iterator.next();
-          if (next.opcode != CodeConstants.opc_dup)
-            return false;
-
-          // varargs array index
-          if (!iterator.hasNext())
-            return false;
-          next = iterator.next();
-          if (next.opcode < CodeConstants.opc_bipush || next.opcode > CodeConstants.opc_sipush
-              || next.operand(0) != j)
-            return false;
-
-          // load argument for varargs array
-          if (!iterator.hasNext())
-            return false;
-          next = iterator.next();
-          if (next.opcode < CodeConstants.opc_iload || next.opcode > CodeConstants.opc_aload
-              || next.operand(0) != argument + j)
-            return false;
-
-          // store argument in varargs array
-          if (!iterator.hasNext())
-            return false;
-          next = iterator.next();
-          if (next.opcode < CodeConstants.opc_iastore || next.opcode > CodeConstants.opc_sastore)
-            return false;
-        }
-
+        // store argument in varargs array
         if (!iterator.hasNext())
           return false;
         next = iterator.next();
+        if (next.opcode < CodeConstants.opc_iastore || next.opcode > CodeConstants.opc_sastore)
+          return false;
       }
-      // invoke method
-      if (next.opcode < CodeConstants.opc_invokevirtual || next.opcode > CodeConstants.opc_invokeinterface)
-        return false;
-
-      Instruction invoke = next;
 
       if (!iterator.hasNext())
         return false;
       next = iterator.next();
-
-      if (next.opcode == CodeConstants.opc_pop) {
-        if (!iterator.hasNext())
-          return false;
-        next = iterator.next();
-      }
-
-      // return
-      if (next.opcode < CodeConstants.opc_ireturn || next.opcode > CodeConstants.opc_return)
-        return false;
-
-      if (iterator.hasNext())
-        return false;
-
-      LinkConstant link = struct.getPool().getLinkConstant(invoke.operand(0));
-      boolean instance = invoke.opcode != CodeConstants.opc_invokestatic
-          && !link.elementname.equals(CodeConstants.INIT_NAME);
-
-      String newClass = link.classname;
-      String newMethod = link.elementname;
-      String newDescriptor = link.descriptor;
-      String newKey = InterpreterUtil.makeUniqueKey(newMethod, newDescriptor);
-
-      StructClass newStructClass = DecompilerContext.getStructContext().getClass(newClass);
-      if (newStructClass == null)
-        return false;
-      StructMethod newStructMethod = newStructClass.getMethodRecursive(newMethod, newDescriptor);
-      if (newStructMethod == null)
-        return false;
-
-      if (newStructMethod.hasModifier(CodeConstants.ACC_SYNTHETIC))
-        return false;
-
-      ClassNode newNode = DecompilerContext.getClassProcessor().getMapRootClasses().get(newClass);
-      if (newNode != null && newNode.type == ClassesProcessor.ClassNode.Type.ANONYMOUS)
-        return false;
-
-      if (method.methodDescriptor().params.length - (varargs ? varargsCount - 1 : 0) != newStructMethod.methodDescriptor().params.length + (instance ? 1 : 0))
-        return false;
-      if (newExprent.getConstructor().getLstParameters().size() > (instance ? 1 : 0))
-        return false;
-      info.content_class_name = newClass;
-      info.content_method_name = newMethod;
-      info.content_method_descriptor = newDescriptor;
-      info.content_method_invocation_type = switch (invoke.opcode) {
-        case CodeConstants.opc_invokevirtual -> CodeConstants.CONSTANT_MethodHandle_REF_invokeVirtual;
-        case CodeConstants.opc_invokespecial -> instance ? CodeConstants.CONSTANT_MethodHandle_REF_newInvokeSpecial : CodeConstants.CONSTANT_MethodHandle_REF_invokeSpecial;
-        case CodeConstants.opc_invokestatic -> CodeConstants.CONSTANT_MethodHandle_REF_invokeStatic;
-        case CodeConstants.opc_invokeinterface -> CodeConstants.CONSTANT_MethodHandle_REF_invokeInterface;
-        default -> -1;
-      };
-      info.content_method_key = newKey;
-      info.is_method_reference = true;
-      info.is_content_method_static = invoke.opcode == CodeConstants.opc_invokestatic;
-      newExprent.setMethodReference(true);
-      InvocationExprent constructor = newExprent.getConstructor();
-      if (instance && constructor.getLstParameters().size() == 1) {
-        constructor.setInstance(constructor.getLstParameters().get(0));
-      }
-
-      if (i > 0) {
-        Exprent instanceExp = newExprent.getConstructor().getInstance();
-        Exprent previous = stat.getExprents().get(i - 1);
-        if (instanceExp instanceof VarExprent varExp
-            && previous instanceof AssignmentExprent assignment
-            && varExp.equalsVersions(assignment.getLeft())
-            && !varExp.isVarReferenced(stat.getTopParent(), (VarExprent) assignment.getLeft())) {
-          newExprent.getConstructor().setInstance(assignment.getRight());
-          newExprent.getConstructor().getLstParameters().set(0, assignment.getRight());
-          stat.getExprents().remove(i - 1);
-        }
-      }
-      return true;
     }
-    return false;
+    // invoke method
+    if (next.opcode < CodeConstants.opc_invokevirtual || next.opcode > CodeConstants.opc_invokeinterface)
+      return false;
+
+    Instruction invoke = next;
+
+    if (!iterator.hasNext())
+      return false;
+    next = iterator.next();
+
+    if (next.opcode == CodeConstants.opc_pop) {
+      if (!iterator.hasNext())
+        return false;
+      next = iterator.next();
+    }
+
+    // return
+    if (next.opcode < CodeConstants.opc_ireturn || next.opcode > CodeConstants.opc_return)
+      return false;
+
+    if (iterator.hasNext())
+      return false;
+
+    LinkConstant link = struct.getPool().getLinkConstant(invoke.operand(0));
+    boolean instance = invoke.opcode != CodeConstants.opc_invokestatic
+        && !link.elementname.equals(CodeConstants.INIT_NAME);
+
+    String newClass = link.classname;
+    String newMethod = link.elementname;
+    String newDescriptor = link.descriptor;
+    String newKey = InterpreterUtil.makeUniqueKey(newMethod, newDescriptor);
+
+    StructClass newStructClass = DecompilerContext.getStructContext().getClass(newClass);
+    if (newStructClass == null)
+      return false;
+    StructMethod newStructMethod = newStructClass.getMethodRecursive(newMethod, newDescriptor);
+    if (newStructMethod == null)
+      return false;
+
+    if (newStructMethod.hasModifier(CodeConstants.ACC_SYNTHETIC))
+      return false;
+
+    ClassNode newNode = DecompilerContext.getClassProcessor().getMapRootClasses().get(newClass);
+    if (newNode != null && newNode.type == ClassesProcessor.ClassNode.Type.ANONYMOUS)
+      return false;
+
+    if (method.methodDescriptor().params.length - (varargs ? varargsCount - 1 : 0) != newStructMethod.methodDescriptor().params.length + (instance ? 1 : 0))
+      return false;
+    if (newExprent.getConstructor().getLstParameters().size() > (instance ? 1 : 0))
+      return false;
+    info.content_class_name = newClass;
+    info.content_method_name = newMethod;
+    info.content_method_descriptor = newDescriptor;
+    info.content_method_invocation_type = switch (invoke.opcode) {
+    case CodeConstants.opc_invokevirtual -> CodeConstants.CONSTANT_MethodHandle_REF_invokeVirtual;
+    case CodeConstants.opc_invokespecial -> instance ? CodeConstants.CONSTANT_MethodHandle_REF_newInvokeSpecial : CodeConstants.CONSTANT_MethodHandle_REF_invokeSpecial;
+    case CodeConstants.opc_invokestatic -> CodeConstants.CONSTANT_MethodHandle_REF_invokeStatic;
+    case CodeConstants.opc_invokeinterface -> CodeConstants.CONSTANT_MethodHandle_REF_invokeInterface;
+    default -> -1;
+    };
+    info.content_method_key = newKey;
+    info.is_method_reference = true;
+    info.is_content_method_static = invoke.opcode == CodeConstants.opc_invokestatic;
+    newExprent.setMethodReference(true);
+    InvocationExprent constructor = newExprent.getConstructor();
+    if (instance && constructor.getLstParameters().size() == 1) {
+      constructor.setInstance(constructor.getLstParameters().get(0));
+    }
+
+    if (i > 0) {
+      Exprent instanceExp = newExprent.getConstructor().getInstance();
+      Exprent previous = stat.getExprents().get(i - 1);
+      if (instanceExp instanceof VarExprent varExp
+          && previous instanceof AssignmentExprent assignment
+          && varExp.equalsVersions(assignment.getLeft())
+          && !varExp.isVarReferenced(stat.getTopParent(), (VarExprent) assignment.getLeft())) {
+        newExprent.getConstructor().setInstance(assignment.getRight());
+        newExprent.getConstructor().getLstParameters().set(0, assignment.getRight());
+        stat.getExprents().remove(i - 1);
+      }
+    }
+    return true;
   }
 
   private static boolean removeInstanceAssignment(Statement stat, int i, Exprent exp) {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
@@ -851,6 +851,10 @@ public class NewExprent extends Exprent {
     return methodReference;
   }
 
+  public void setMethodReference(boolean methodReference) {
+    this.methodReference = methodReference;
+  }
+
   public String getLambdaMethodKey() {
     ClassNode node = DecompilerContext.getClassProcessor().getMapRootClasses().get(newType.value);
     if (node != null && constructor != null) {

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -793,6 +793,8 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_8, "TestTryLoopSimpleFinally");
     register(JAVA_8, "TestTryLoopReturnFinally");
     register(JASM, "TestNumberCompareToBoolean");
+
+    register(JAVA_25, "TestMethodReferenceJ25");
   }
 
   private void registerEntireClassPath() {

--- a/testData/results/pkg/TestGenericsQualified.dec
+++ b/testData/results/pkg/TestGenericsQualified.dec
@@ -6,11 +6,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 public class TestGenericsQualified {
-   public Comparator<String> field = Comparator.<String, Integer>comparing(s -> s.length()).thenComparing(i -> i.toString());// 10
+   public Comparator<String> field = Comparator.<String, Integer>comparing(s -> s.length()).thenComparing(String::toString);// 10
    public CompletableFuture<String> field2 = CompletableFuture.<String>supplyAsync(() -> "").thenCompose(s -> CompletableFuture.supplyAsync(() -> s + "2"));// 11
    public Optional<String> field3 = Optional.of("").map(s -> s + "3");// 12
-   public Stream<String> field4 = Stream.of("1", "2").sorted(Comparator.<String, Integer>comparing(s -> s.length()).thenComparing(i -> i.toString()));// 13 14
-   public Comparator<String> field5 = Comparator.comparing(String::length).thenComparing(i -> i.toString());// 15
+   public Stream<String> field4 = Stream.of("1", "2").sorted(Comparator.<String, Integer>comparing(s -> s.length()).thenComparing(String::toString));// 13 14
+   public Comparator<String> field5 = Comparator.comparing(String::length).thenComparing(String::toString);// 15
    public Comparator<TestGenericsQualified> field6 = Comparator.<TestGenericsQualified, Integer>comparing(TestGenericsQualified::get).reversed();// 16
 
    public int get() {
@@ -22,7 +22,7 @@ public class TestGenericsQualified {
    }
 
    public Comparator<String> method() {
-      return Comparator.<String, Integer>comparing(s -> s.length()).thenComparing(i -> i.toString());// 27
+      return Comparator.<String, Integer>comparing(s -> s.length()).thenComparing(String::toString);// 27
    }
 }
 
@@ -99,14 +99,6 @@ class 'pkg/TestGenericsQualified' {
       7      8
    }
 
-   method 'lambda$new$1 (Ljava/lang/String;)Ljava/lang/String;' {
-      0      8
-      1      8
-      2      8
-      3      8
-      4      8
-   }
-
    method 'lambda$new$2 ()Ljava/lang/String;' {
       0      9
       1      9
@@ -151,22 +143,6 @@ class 'pkg/TestGenericsQualified' {
       7      11
    }
 
-   method 'lambda$new$7 (Ljava/lang/String;)Ljava/lang/String;' {
-      0      11
-      1      11
-      2      11
-      3      11
-      4      11
-   }
-
-   method 'lambda$new$8 (Ljava/lang/String;)Ljava/lang/String;' {
-      0      12
-      1      12
-      2      12
-      3      12
-      4      12
-   }
-
    method 'get ()I' {
       0      16
       1      16
@@ -198,14 +174,6 @@ class 'pkg/TestGenericsQualified' {
       5      24
       6      24
       7      24
-   }
-
-   method 'lambda$method$10 (Ljava/lang/String;)Ljava/lang/String;' {
-      0      24
-      1      24
-      2      24
-      3      24
-      4      24
    }
 }
 

--- a/testData/results/pkg/TestLocalRecord.dec
+++ b/testData/results/pkg/TestLocalRecord.dec
@@ -34,21 +34,21 @@ public class TestLocalRecord {
       record R() {
       }
 
-      Supplier<R> constr = () -> new R();// 29
+      Supplier<R> constr = R::new;// 29
    }// 30
 
    public Supplier<Supplier<Object>> test5() {
       record R() {
       }
 
-      return () -> () -> new R();// 34
+      return () -> R::new;// 34
    }
 
    public Supplier<Object> test6() {
       record R() {
       }
 
-      return () -> new R();// 39
+      return R::new;// 39
    }
 }
 
@@ -119,10 +119,6 @@ class 'pkg/TestLocalRecord' {
       6      37
    }
 
-   method 'lambda$test4$0 ()Lpkg/TestLocalRecord$3R;' {
-      7      36
-   }
-
    method 'test5 ()Ljava/util/function/Supplier;' {
       5      43
    }
@@ -131,16 +127,8 @@ class 'pkg/TestLocalRecord' {
       5      43
    }
 
-   method 'lambda$test5$1 ()Ljava/lang/Object;' {
-      7      43
-   }
-
    method 'test6 ()Ljava/util/function/Supplier;' {
       5      50
-   }
-
-   method 'lambda$test6$3 ()Ljava/lang/Object;' {
-      7      50
    }
 }
 

--- a/testData/results/pkg/TestMethodReferenceJ25.dec
+++ b/testData/results/pkg/TestMethodReferenceJ25.dec
@@ -1,0 +1,129 @@
+package pkg;
+
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+
+public class TestMethodReferenceJ25 {
+   // $VF: Variable merging failed for merge VarExprent[10000,0]: {var10000}. Code has semantic differences!
+   protected void test() {
+      Object var10000;
+      BiFunction<Object, Object, Object> c1 = this.getThis()::test1;// 8
+      BiFunction<Object, Object, Object> c2 = this.getThis()::test2;// 9
+      BiFunction<Object, Object, Object> c3 = this.getThis()::test3;// 10
+      BiFunction<Object, Object, Object> c4 = this.getThis()::test4;// 11
+      BiFunction<Object, Object, TestMethodReferenceJ25> c5 = TestMethodReferenceJ25::new;// 12
+      BiConsumer<Object, Object> c6 = this.getThis()::test5;// 13
+   }// 14
+
+   public TestMethodReferenceJ25(Object... o1) {
+   }// 18
+
+   protected Object test1(Object... o1) {
+      return o1;// 21
+   }
+
+   protected Object test2(Object o1, Object... o2) {
+      return o1;// 25
+   }
+
+   protected Object test3(Object o1, Object o2, Object... o3) {
+      return o1;// 29
+   }
+
+   protected Object test4(Object o1, Object o2) {
+      return o1;// 33
+   }
+
+   protected void test5(Object... o1) {
+   }// 37
+
+   public TestMethodReferenceJ25 getThis() {
+      return this;// 40
+   }
+}
+
+class 'pkg/TestMethodReferenceJ25' {
+   method 'test ()V' {
+      0      9
+      1      9
+      2      9
+      3      9
+      10      9
+      11      10
+      12      10
+      13      10
+      14      10
+      21      10
+      22      11
+      23      11
+      24      11
+      25      11
+      34      11
+      35      12
+      36      12
+      37      12
+      38      12
+      43      12
+      44      12
+      4a      13
+      4b      13
+      4c      14
+      4d      14
+      4e      14
+      4f      14
+      5e      14
+      5f      14
+      60      15
+   }
+
+   method '<init> ([Ljava/lang/Object;)V' {
+      4      18
+   }
+
+   method 'test1 ([Ljava/lang/Object;)Ljava/lang/Object;' {
+      0      21
+      1      21
+   }
+
+   method 'test2 (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' {
+      0      25
+      1      25
+   }
+
+   method 'test3 (Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' {
+      0      29
+      1      29
+   }
+
+   method 'test4 (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' {
+      0      33
+      1      33
+   }
+
+   method 'test5 ([Ljava/lang/Object;)V' {
+      0      37
+   }
+
+   method 'getThis ()Lpkg/TestMethodReferenceJ25;' {
+      0      40
+      1      40
+   }
+}
+
+Lines mapping:
+8 <-> 10
+9 <-> 11
+10 <-> 12
+11 <-> 13
+12 <-> 14
+13 <-> 15
+14 <-> 16
+18 <-> 19
+21 <-> 22
+25 <-> 26
+29 <-> 30
+33 <-> 34
+37 <-> 38
+40 <-> 41
+Not mapped:
+16

--- a/testData/results/pkg/TestMethodReferenceJ25.dec
+++ b/testData/results/pkg/TestMethodReferenceJ25.dec
@@ -4,9 +4,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
 public class TestMethodReferenceJ25 {
-   // $VF: Variable merging failed for merge VarExprent[10000,0]: {var10000}. Code has semantic differences!
    protected void test() {
-      Object var10000;
       BiFunction<Object, Object, Object> c1 = this.getThis()::test1;// 8
       BiFunction<Object, Object, Object> c2 = this.getThis()::test2;// 9
       BiFunction<Object, Object, Object> c3 = this.getThis()::test3;// 10
@@ -44,86 +42,86 @@ public class TestMethodReferenceJ25 {
 
 class 'pkg/TestMethodReferenceJ25' {
    method 'test ()V' {
-      0      9
-      1      9
-      2      9
-      3      9
-      10      9
-      11      10
-      12      10
-      13      10
-      14      10
-      21      10
-      22      11
-      23      11
-      24      11
-      25      11
-      34      11
-      35      12
-      36      12
-      37      12
-      38      12
-      43      12
-      44      12
-      4a      13
-      4b      13
-      4c      14
-      4d      14
-      4e      14
-      4f      14
-      5e      14
-      5f      14
-      60      15
+      0      7
+      1      7
+      2      7
+      3      7
+      10      7
+      11      8
+      12      8
+      13      8
+      14      8
+      21      8
+      22      9
+      23      9
+      24      9
+      25      9
+      34      9
+      35      10
+      36      10
+      37      10
+      38      10
+      43      10
+      44      10
+      4a      11
+      4b      11
+      4c      12
+      4d      12
+      4e      12
+      4f      12
+      5e      12
+      5f      12
+      60      13
    }
 
    method '<init> ([Ljava/lang/Object;)V' {
-      4      18
+      4      16
    }
 
    method 'test1 ([Ljava/lang/Object;)Ljava/lang/Object;' {
-      0      21
-      1      21
+      0      19
+      1      19
    }
 
    method 'test2 (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' {
-      0      25
-      1      25
+      0      23
+      1      23
    }
 
    method 'test3 (Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;' {
-      0      29
-      1      29
+      0      27
+      1      27
    }
 
    method 'test4 (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' {
-      0      33
-      1      33
+      0      31
+      1      31
    }
 
    method 'test5 ([Ljava/lang/Object;)V' {
-      0      37
+      0      35
    }
 
    method 'getThis ()Lpkg/TestMethodReferenceJ25;' {
-      0      40
-      1      40
+      0      38
+      1      38
    }
 }
 
 Lines mapping:
-8 <-> 10
-9 <-> 11
-10 <-> 12
-11 <-> 13
-12 <-> 14
-13 <-> 15
-14 <-> 16
-18 <-> 19
-21 <-> 22
-25 <-> 26
-29 <-> 30
-33 <-> 34
-37 <-> 38
-40 <-> 41
+8 <-> 8
+9 <-> 9
+10 <-> 10
+11 <-> 11
+12 <-> 12
+13 <-> 13
+14 <-> 14
+18 <-> 17
+21 <-> 20
+25 <-> 24
+29 <-> 28
+33 <-> 32
+37 <-> 36
+40 <-> 39
 Not mapped:
 16

--- a/testData/src/java25/pkg/TestMethodReferenceJ25.java
+++ b/testData/src/java25/pkg/TestMethodReferenceJ25.java
@@ -1,0 +1,42 @@
+package pkg;
+
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+
+public class TestMethodReferenceJ25 {
+  protected void test() {
+    BiFunction<Object, Object, Object> c1 = getThis()::test1;
+    BiFunction<Object, Object, Object> c2 = getThis()::test2;
+    BiFunction<Object, Object, Object> c3 = getThis()::test3;
+    BiFunction<Object, Object, Object> c4 = getThis()::test4;
+    BiFunction<Object, Object, TestMethodReferenceJ25> c5 = TestMethodReferenceJ25::new;
+    BiConsumer<Object, Object> c6 = getThis()::test5;
+  }
+
+  public TestMethodReferenceJ25(Object... o1) {
+
+  }
+
+  protected Object test1(Object... o1) {
+    return o1;
+  }
+
+  protected Object test2(Object o1, Object... o2) {
+    return o1;
+  }
+
+  protected Object test3(Object o1, Object o2, Object... o3) {
+    return o1;
+  }
+
+  protected Object test4(Object o1, Object o2) {
+    return o1;
+  }
+
+  protected void test5(Object... o1) {
+  }
+
+  public TestMethodReferenceJ25 getThis() {
+    return this;
+  }
+}


### PR DESCRIPTION
Converts lambdas to method references when javac compiles a method reference to a lambda, removes synthetic instance variable, and removes `Objects.requireNonNull`.