### PR TITLE
Add helper case functions

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
@@ -584,7 +584,7 @@ public class SwitchStatement extends Statement {
     this.getCaseStatements().add(index, stat);
     this.getCaseValues().add(index, !isAddDefault ? values : Collections.singletonList(null));
 
-    if (values != null) {
+    if (!isAddDefault) {
       var newCaseEdgeLst = new ArrayList<StatEdge>();
       for (int i = 0; i < values.size(); i++) {
         final var edge = new StatEdge(StatEdge.TYPE_REGULAR, this.getBasichead(), stat);
@@ -592,10 +592,10 @@ public class SwitchStatement extends Statement {
 
         this.getBasichead().addSuccessor(edge);
       }
-      this.getCaseEdges().add(index, newCaseEdgeLst);
-    }
 
-    if (isAddDefault) {
+      this.getCaseEdges().add(index, newCaseEdgeLst);
+    } else {
+      // Just add the default and move on!
       final var edge = new StatEdge(StatEdge.TYPE_REGULAR, this.getBasichead(), stat);
       this.setDefaultEdge(edge);
     }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
@@ -1,6 +1,8 @@
 // Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.jetbrains.java.decompiler.modules.decompiler.stats;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.java.decompiler.code.SwitchInstruction;
 import org.jetbrains.java.decompiler.code.cfg.BasicBlock;
 import org.jetbrains.java.decompiler.main.DecompilerContext;
@@ -152,8 +154,7 @@ public class SwitchStatement extends Statement {
           if (value instanceof ConstExprent && !value.getExprType().equals(VarType.VARTYPE_NULL)) {
             value = value.copy();
             ((ConstExprent)value).setConstType(switch_type);
-          } if (value instanceof FieldExprent && ((FieldExprent)value).isStatic()) { // enum values
-            FieldExprent field = (FieldExprent) value;
+          } if (value instanceof FieldExprent field && field.isStatic()) { // enum values
             buf.appendField(field.getName(), false, field.getClassname(), field.getName(), field.getDescriptor());
           } else if (value instanceof FunctionExprent && ((FunctionExprent) value).getFuncType() == FunctionType.INSTANCEOF) {
             // Pattern matching variables
@@ -512,7 +513,7 @@ public class SwitchStatement extends Statement {
     return caseStatements;
   }
 
-  public StatEdge getDefaultEdge() {
+  public @Nullable StatEdge getDefaultEdge() {
     return defaultEdge;
   }
 
@@ -534,5 +535,81 @@ public class SwitchStatement extends Statement {
 
   public void setDefaultEdge(StatEdge edge) {
     this.defaultEdge = edge;
+  }
+
+  public Optional<Statement> getDefaultCase() {
+    return Optional.ofNullable(this.getDefaultEdge() != null ? this.getDefaultEdge().getDestination() : null);
+  }
+
+  public void setDefaultCase(Statement stat) {
+    final var defaultCase = this.getDefaultCase();
+    if (defaultCase.isPresent()) {
+      defaultCase.get().replaceWith(stat);
+      return;
+    }
+
+    final var index = this.getCaseStatements().size();
+    this.addCaseInternal(index, null, stat);
+  }
+
+  public void addCase(List<@NotNull Exprent> values, Statement stat) {
+    final var caseCount = this.getCaseStatements().size();
+    this.addCaseInternal(this.getDefaultEdge() != null ? caseCount - 1 : caseCount, values, stat);
+  }
+
+  public void addCase(int index, List<@NotNull Exprent> values, Statement stat) {
+    this.addCaseInternal(index, values, stat);
+  }
+
+  private void addCaseInternal(int index, @Nullable List<Exprent> values, Statement stat) {
+    final var isAddDefault = values == null;
+
+    // Basichead is always the first stat
+    this.getStats().add(1 + index, stat);
+    this.getCaseStatements().add(index, stat);
+
+    this.getCaseValues().add(index, !isAddDefault ? values : Collections.singletonList(null));
+
+    if (values != null) {
+      var newCaseEdgeLst = new ArrayList<StatEdge>();
+      for (int i = 0; i < values.size(); i++) {
+        final var edge = new StatEdge(StatEdge.TYPE_REGULAR, this.getBasichead(), stat);
+        newCaseEdgeLst.add(i, edge);
+
+        this.getBasichead().addSuccessor(edge);
+      }
+      this.getCaseEdges().add(index, newCaseEdgeLst);
+    }
+
+    if (isAddDefault) {
+      final var edge = new StatEdge(StatEdge.TYPE_REGULAR, this.getBasichead(), stat);
+      this.setDefaultEdge(edge);
+    }
+
+    stat.setParent(this);
+  }
+
+  public void removeCase(Statement stat) {
+    final var index = this.caseStatements.indexOf(stat);
+    if (index == -1) {
+      throw new IllegalStateException("Tried to remove a case statement that isn't in the switch!");
+    }
+
+    this.removeCase(index);
+  }
+
+  /**
+   * Removes a case from the switch statement. This includes the case statement, values, and edges.
+   * @param index the index of the case
+   */
+  public void removeCase(int index) {
+    this.getCaseStatements().get(index).getAllPredecessorEdges().forEach(StatEdge::remove);
+    this.getCaseStatements().get(index).getAllSuccessorEdges().forEach(StatEdge::remove);
+
+    this.getStats().remove(this.getCaseStatements().get(index));
+    this.getCaseStatements().remove(index);
+    this.getCaseValues().remove(index);
+    this.getCaseEdges().get(index).forEach(StatEdge::remove);
+    this.getCaseEdges().remove(index);
   }
 }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
@@ -551,7 +551,7 @@ public class SwitchStatement extends Statement {
       defaultCase.get().replaceWith(stat);
       return;
     }
-    
+
     this.addCaseInternal(0, null, stat);
   }
 

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
@@ -552,8 +552,7 @@ public class SwitchStatement extends Statement {
       return;
     }
     
-    final var index = this.getCaseStatements().size();
-    this.addCaseInternal(index, null, stat);
+    this.addCaseInternal(0, null, stat);
   }
 
   /**

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
@@ -538,7 +538,8 @@ public class SwitchStatement extends Statement {
   }
 
   public Optional<Statement> getDefaultCase() {
-    return Optional.ofNullable(this.getDefaultEdge() != null ? this.getDefaultEdge().getDestination() : null);
+    final var defaultEdge = this.getDefaultEdge();
+    return defaultEdge != null ? Optional.of(defaultEdge.getDestination()) : Optional.empty();
   }
 
   /**

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
@@ -541,22 +541,37 @@ public class SwitchStatement extends Statement {
     return Optional.ofNullable(this.getDefaultEdge() != null ? this.getDefaultEdge().getDestination() : null);
   }
 
+  /**
+   * Replaces the default case if it exists. Adds a new default case to the switch if it doesn't exist.
+   * @param stat the case statement to be linked to
+   */
   public void setDefaultCase(Statement stat) {
     final var defaultCase = this.getDefaultCase();
     if (defaultCase.isPresent()) {
       defaultCase.get().replaceWith(stat);
       return;
     }
-
+    
     final var index = this.getCaseStatements().size();
     this.addCaseInternal(index, null, stat);
   }
 
+  /**
+   * Adds a new case to the switch.
+   * @param values the list of non-null exprents to use as case values
+   * @param stat the case statement to be linked to
+   */
   public void addCase(List<@NotNull Exprent> values, Statement stat) {
     final var caseCount = this.getCaseStatements().size();
     this.addCaseInternal(this.getDefaultEdge() != null ? caseCount - 1 : caseCount, values, stat);
   }
 
+  /**
+   * Adds a new case to the switch.
+   * @param index the index of where the case should be added
+   * @param values the list of non-null exprents to use as case values
+   * @param stat the case statement to be linked to
+   */
   public void addCase(int index, List<@NotNull Exprent> values, Statement stat) {
     this.addCaseInternal(index, values, stat);
   }
@@ -567,7 +582,6 @@ public class SwitchStatement extends Statement {
     // Basichead is always the first stat
     this.getStats().add(1 + index, stat);
     this.getCaseStatements().add(index, stat);
-
     this.getCaseValues().add(index, !isAddDefault ? values : Collections.singletonList(null));
 
     if (values != null) {
@@ -589,6 +603,11 @@ public class SwitchStatement extends Statement {
     stat.setParent(this);
   }
 
+  /**
+   * Removes a case from the switch statement. This includes the case statement, values, and edges.
+   * You should NOT manually handle stats/values/edges if you are calling this method.
+   * @param stat the case statement to remove
+   */
   public void removeCase(Statement stat) {
     final var index = this.caseStatements.indexOf(stat);
     if (index == -1) {
@@ -600,7 +619,8 @@ public class SwitchStatement extends Statement {
 
   /**
    * Removes a case from the switch statement. This includes the case statement, values, and edges.
-   * @param index the index of the case
+   * You should NOT manually handle stats/values/edges if you are calling this method.
+   * @param index the index of the case to remove
    */
   public void removeCase(int index) {
     this.getCaseStatements().get(index).getAllPredecessorEdges().forEach(StatEdge::remove);

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
@@ -560,7 +560,7 @@ public class SwitchStatement extends Statement {
    * @param values the list of non-null exprents to use as case values
    * @param stat the case statement to be linked to
    */
-  public void addCase(List<@NotNull Exprent> values, Statement stat) {
+  public void addCase(List<Exprent> values, Statement stat) {
     final var caseCount = this.getCaseStatements().size();
     this.addCaseInternal(this.getDefaultEdge() != null ? caseCount - 1 : caseCount, values, stat);
   }
@@ -568,10 +568,10 @@ public class SwitchStatement extends Statement {
   /**
    * Adds a new case to the switch.
    * @param index the index of where the case should be added
-   * @param values the list of non-null exprents to use as case values
+   * @param values the list of exprents to use as case values
    * @param stat the case statement to be linked to
    */
-  public void addCase(int index, List<@NotNull Exprent> values, Statement stat) {
+  public void addCase(int index, List<Exprent> values, Statement stat) {
     this.addCaseInternal(index, values, stat);
   }
 

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
@@ -538,7 +538,7 @@ public class SwitchStatement extends Statement {
   }
 
   public Optional<Statement> getDefaultCase() {
-    final var defaultEdge = this.getDefaultEdge();
+    StatEdge defaultEdge = this.getDefaultEdge();
     return defaultEdge != null ? Optional.of(defaultEdge.getDestination()) : Optional.empty();
   }
 
@@ -547,7 +547,7 @@ public class SwitchStatement extends Statement {
    * @param stat the case statement to be linked to
    */
   public void setDefaultCase(Statement stat) {
-    final var defaultCase = this.getDefaultCase();
+    Optional<Statement> defaultCase = this.getDefaultCase();
     if (defaultCase.isPresent()) {
       defaultCase.get().replaceWith(stat);
       return;
@@ -562,7 +562,7 @@ public class SwitchStatement extends Statement {
    * @param stat the case statement to be linked to
    */
   public void addCase(List<Exprent> values, Statement stat) {
-    final var caseCount = this.getCaseStatements().size();
+    int caseCount = this.getCaseStatements().size();
     this.addCaseInternal(this.getDefaultEdge() != null ? caseCount - 1 : caseCount, values, stat);
   }
 
@@ -577,7 +577,7 @@ public class SwitchStatement extends Statement {
   }
 
   private void addCaseInternal(int index, @Nullable List<Exprent> values, Statement stat) {
-    final var isAddDefault = values == null;
+    boolean isAddDefault = values == null;
 
     // Basichead is always the first stat
     this.getStats().add(1 + index, stat);
@@ -585,9 +585,9 @@ public class SwitchStatement extends Statement {
     this.getCaseValues().add(index, !isAddDefault ? values : Collections.singletonList(null));
 
     if (!isAddDefault) {
-      var newCaseEdgeLst = new ArrayList<StatEdge>();
+      ArrayList<StatEdge> newCaseEdgeLst = new ArrayList<>();
       for (int i = 0; i < values.size(); i++) {
-        final var edge = new StatEdge(StatEdge.TYPE_REGULAR, this.getBasichead(), stat);
+        StatEdge edge = new StatEdge(StatEdge.TYPE_REGULAR, this.getBasichead(), stat);
         newCaseEdgeLst.add(i, edge);
 
         this.getBasichead().addSuccessor(edge);
@@ -596,7 +596,7 @@ public class SwitchStatement extends Statement {
       this.getCaseEdges().add(index, newCaseEdgeLst);
     } else {
       // Just add the default and move on!
-      final var edge = new StatEdge(StatEdge.TYPE_REGULAR, this.getBasichead(), stat);
+      StatEdge edge = new StatEdge(StatEdge.TYPE_REGULAR, this.getBasichead(), stat);
       this.setDefaultEdge(edge);
     }
 
@@ -609,7 +609,7 @@ public class SwitchStatement extends Statement {
    * @param stat the case statement to remove
    */
   public void removeCase(Statement stat) {
-    final var index = this.caseStatements.indexOf(stat);
+    int index = this.caseStatements.indexOf(stat);
     if (index == -1) {
       throw new IllegalStateException("Tried to remove a case statement that isn't in the switch!");
     }


### PR DESCRIPTION
Very simple helper functions for case manipulation for switches. Will change a little later when I add a case class to SwitchStatement to further clean it up.

(cherry picked from commit decdb6efbe849567c4dbb01bf82a653cf39e2b80)