### PR TITLE
Inline temp return variables after try-with-resources reconstruction

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessor.java
+++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessor.java
@@ -346,6 +346,14 @@ public class MethodProcessor implements Runnable {
         continue;
       }
 
+      // After try-with-resources reconstruction is complete, inline temp
+      // return variables left over from JDK 9+ TWR desugaring.
+      if (root.hasTryCatch() && TryHelper.inlineTwrReturnVars(root)) {
+        SequenceHelper.condenseSequences(root);
+        decompileRecord.add("InlineTwrReturnVars", root);
+        continue;
+      }
+
       if (InlineSingleBlockHelper.inlineSingleBlocks(root)) {
         decompileRecord.add("InlineSingleBlocks", root);
         continue;

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/TryHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/TryHelper.java
@@ -1,6 +1,6 @@
 package org.jetbrains.java.decompiler.modules.decompiler;
 
-import org.jetbrains.java.decompiler.modules.decompiler.exps.Exprent;
+import org.jetbrains.java.decompiler.modules.decompiler.exps.*;
 import org.jetbrains.java.decompiler.modules.decompiler.stats.*;
 import org.jetbrains.java.decompiler.struct.StructClass;
 
@@ -125,5 +125,80 @@ public class TryHelper {
     }
 
     return false;
+  }
+
+  // After JDK 9+ try-with-resources reconstruction, temp return variables may
+  // be left over from the desugaring pattern:
+  //   try (...) { ...; var = value; }
+  //   return var;
+  // This pass inlines them to:
+  //   try (...) { ...; return value; }
+  public static boolean inlineTwrReturnVars(Statement stat) {
+    boolean changed = false;
+
+    for (Statement st : new ArrayList<>(stat.getStats())) {
+      if (inlineTwrReturnVars(st)) {
+        changed = true;
+      }
+    }
+
+    if (stat instanceof SequenceStatement) {
+      for (int i = 0; i < stat.getStats().size() - 1; i++) {
+        Statement curr = stat.getStats().get(i);
+        Statement next = stat.getStats().get(i + 1);
+
+        if (curr instanceof CatchStatement catchStat
+            && !catchStat.getResources().isEmpty()
+            && next instanceof BasicBlockStatement
+            && next.getExprents() != null
+            && next.getExprents().size() == 1
+            && next.getExprents().get(0) instanceof ExitExprent exitExpr
+            && exitExpr.getExitType() == ExitExprent.Type.RETURN
+            && exitExpr.getValue() instanceof VarExprent returnVar) {
+
+          Statement tryBody = catchStat.getFirst();
+          Statement lastInBody = findLastStatement(tryBody);
+
+          if (lastInBody != null
+              && lastInBody.getExprents() != null
+              && !lastInBody.getExprents().isEmpty()) {
+            List<Exprent> bodyExprents = lastInBody.getExprents();
+            Exprent lastExpr = bodyExprents.get(bodyExprents.size() - 1);
+
+            if (lastExpr instanceof AssignmentExprent assignment
+                && assignment.getCondType() == null
+                && assignment.getLeft() instanceof VarExprent assignVar
+                && assignVar.equals(returnVar)) {
+
+              ExitExprent newReturn = (ExitExprent) exitExpr.copy();
+              newReturn.replaceExprent(newReturn.getValue(), assignment.getRight().copy());
+              bodyExprents.set(bodyExprents.size() - 1, newReturn);
+
+              next.getExprents().clear();
+              changed = true;
+            }
+          }
+        }
+      }
+    }
+
+    return changed;
+  }
+
+  private static Statement findLastStatement(Statement stat) {
+    if (stat instanceof SequenceStatement) {
+      Statement last = stat.getStats().get(stat.getStats().size() - 1);
+      return findLastStatement(last);
+    }
+
+    if (stat instanceof CatchStatement) {
+      return findLastStatement(((CatchStatement) stat).getFirst());
+    }
+
+    if (stat.getExprents() != null) {
+      return stat;
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
## Problem

When decompiling methods compiled with JDK 9+ that use try-with-resources with multiple exit paths, the desugaring pattern leaves behind temp variables after reconstruction:

```java
try (...) { ...; var = value; }
return var;
```

For some methods, particularly those with two return paths through the same TWR block, the temp variable assignment gets truncated or produces invalid Java. The second exit path's return value can be lost entirely, leaving just a bare type keyword followed by nothing.

## Example

A method that reads 4 bytes from a DataInputStream, checks for a magic header, and returns either `readInt()` or `1`:

**Original bytecode pattern (JDK 9+ TWR desugaring):**
```
// Path 1 (match):    readInt() -> istore temp -> close streams -> iload temp -> ireturn
// Path 2 (no match): iconst_1  -> istore temp -> close streams -> iload temp -> ireturn
```

**Before this fix:** Path 2 produces truncated output (bare `byte` keyword with no variable name or value).

**After this fix:** Both paths correctly produce `return readInt();` and `return 1;` inside the try-with-resources block.

## Fix

Adds `TryHelper.inlineTwrReturnVars`, a pass that runs in the main loop after `enhanceTryStats` completes (when TWR reconstruction is done). It finds sequences where:

1. A try-with-resources `CatchStatement` (has non-empty resources) is followed by
2. A basic block containing a single `return var;` expression, and
3. The last expression in the try body assigns to that same variable

When matched, it replaces the assignment with `return value;` and clears the trailing return.

The pass also includes `findLastStatement`, a helper that walks sequences, try bodies, and catch statements to find the deepest last statement in the normal execution path.

## Discovery

Found while decompiling Project Zomboid Build 41 (compiled with Zulu JDK 17.0.1). Several methods that read binary file headers produced invalid Java output because the second return path through a try-with-resources block was truncated.

## Existing test impact

The `TestTryWithResourcesReturnJ16` test already demonstrates this bug. Its `test()` and `testFunc()` methods show `var3 = scanner; } return var3;` where the correct output is `return scanner;` inside the try block. Running the test suite with this fix should update those expected outputs.