### PR TITLE
Handle object construction and related constructs

### DIFF
--- a/plugins/kotlin/src/main/java/org/vineflower/kotlin/KotlinWriter.java
+++ b/plugins/kotlin/src/main/java/org/vineflower/kotlin/KotlinWriter.java
@@ -2,6 +2,7 @@
 package org.vineflower.kotlin;
 
 import org.jetbrains.java.decompiler.modules.decompiler.*;
+import org.vineflower.kotlin.expr.KNewExprent;
 import org.vineflower.kt.metadata.ProtoBuf;
 import org.vineflower.kt.metadata.deserialization.Flags;
 import net.fabricmc.fernflower.api.IFabricJavadocProvider;
@@ -769,6 +770,10 @@ public class KotlinWriter implements StatementWriter, Flags {
           if (paramAttr != null) {
             Exprent kExpr = KUtils.replaceExprent(paramAttr.getDefaultValue());
             Exprent expr = kExpr != null ? kExpr : paramAttr.getDefaultValue();
+            VarType returnType = mt.methodDescriptor().ret;
+            if (expr instanceof KNewExprent knew) {
+              knew.setInAnnotation(true);
+            }
             buffer.append(" = ").append(expr.toJava());
           }
         }

--- a/plugins/kotlin/src/main/java/org/vineflower/kotlin/expr/KNewExprent.java
+++ b/plugins/kotlin/src/main/java/org/vineflower/kotlin/expr/KNewExprent.java
@@ -207,6 +207,43 @@ public class KNewExprent extends NewExprent implements KExprent {
         buf.append(element.toJava(indent));
         first = false;
       }
+    } else if (getLstArrayElements().isEmpty()) {
+      //TODO there should never be a multi-dimension new array created here - check if the handling is necessary
+      for (int i = 0; i < getNewType().arrayDim - 1; i++) {
+        buf.append("Array(");
+        Exprent dim = getLstDims().get(i);
+        if (dim.type == Type.CONST) {
+          ((ConstExprent) dim).adjustConstType(VarType.VARTYPE_INT);
+        }
+        buf.append(dim.toJava(indent));
+        buf.append(") {");
+        buf.pushNewlineGroup(indent, 1);
+        buf.appendPossibleNewline(" ");
+      }
+
+      buf.append(switch (getNewType().resizeArrayDim(0).type) {
+        case BOOLEAN -> "BooleanArray";
+        case BYTE -> "ByteArray";
+        case SHORT -> "ShortArray";
+        case CHAR -> "CharArray";
+        case INT -> "IntArray";
+        case FLOAT -> "FloatArray";
+        case LONG -> "LongArray";
+        case DOUBLE -> "DoubleArray";
+        default -> "arrayOfNulls";
+      }).append('(');
+
+      Exprent dim = getLstDims().get(getNewType().arrayDim - 1);
+      if (dim.type == Type.CONST) {
+        ((ConstExprent) dim).adjustConstType(VarType.VARTYPE_INT);
+      }
+      buf.append(dim.toJava(indent)).append(')');
+
+      for (int i = 0; i < getNewType().arrayDim - 1; i++) {
+        buf.appendPossibleNewline(" ", true);
+        buf.popNewlineGroup();
+        buf.append('}');
+      }
     } else {
       buf.append(switch (getNewType().decreaseArrayDim().type) {
         case BOOLEAN -> "booleanArrayOf";

--- a/plugins/kotlin/src/main/java/org/vineflower/kotlin/expr/KNewExprent.java
+++ b/plugins/kotlin/src/main/java/org/vineflower/kotlin/expr/KNewExprent.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 public class KNewExprent extends NewExprent implements KExprent {
   private static final String REFERENCE_CTOR_DESC = "(Ljava/lang/Object;)V";
+  private boolean inAnnotation;
 
   public KNewExprent(NewExprent expr) {
     super(expr.getNewType(), expr.getLstDims(), expr.bytecode);
@@ -207,6 +208,24 @@ public class KNewExprent extends NewExprent implements KExprent {
         buf.append(element.toJava(indent));
         first = false;
       }
+    } else if (inAnnotation) {
+      buf.append('[');
+      buf.pushNewlineGroup(indent, 1);
+      buf.appendPossibleNewline();
+      boolean first = true;
+      for (Exprent element : getLstArrayElements()) {
+        if (!first) {
+          buf.append(",").appendPossibleNewline(" ");
+        }
+        if (element instanceof KNewExprent knew) {
+          knew.setInAnnotation(true);
+        }
+        buf.append(element.toJava(indent));
+        first = false;
+      }
+      buf.appendPossibleNewline("", true);
+      buf.popNewlineGroup();
+      buf.append(']');
     } else if (getLstArrayElements().isEmpty()) {
       //TODO there should never be a multi-dimension new array created here - check if the handling is necessary
       for (int i = 0; i < getNewType().arrayDim - 1; i++) {
@@ -278,5 +297,9 @@ public class KNewExprent extends NewExprent implements KExprent {
   @Override
   public Exprent copy() {
     return new KNewExprent((NewExprent) super.copy());
+  }
+
+  public void setInAnnotation(boolean inAnnotation) {
+    this.inAnnotation = inAnnotation;
   }
 }

--- a/plugins/kotlin/src/main/java/org/vineflower/kotlin/expr/KNewExprent.java
+++ b/plugins/kotlin/src/main/java/org/vineflower/kotlin/expr/KNewExprent.java
@@ -18,7 +18,10 @@ import org.jetbrains.java.decompiler.util.TextBuffer;
 import org.vineflower.kotlin.KotlinChooser;
 import org.vineflower.kotlin.KotlinWriter;
 import org.vineflower.kotlin.metadata.KotlinMetadata;
+import org.vineflower.kotlin.struct.KType;
+import org.vineflower.kotlin.util.KExprProcessor;
 import org.vineflower.kotlin.util.KTypes;
+import org.vineflower.kotlin.util.KUtils;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -46,21 +49,21 @@ public class KNewExprent extends NewExprent implements KExprent {
 
   @Override
   public TextBuffer toJava(int indent) {
+    TextBuffer buf = new TextBuffer();
     ClassesProcessor.ClassNode node = DecompilerContext.getClassProcessor().getMapRootClasses().get(getNewType().value);
     if (node != null && new KotlinChooser().isLanguage(node.classStruct)) {
       KotlinMetadata ktData = node.classStruct.getAttribute(KotlinMetadata.KEY);
       if (ktData.metadata instanceof KotlinMetadata.FunctionReference) {
         Exprent receiver = getConstructor().getLstParameters().get(0);
-        TextBuffer buf = KotlinWriter.stringifyReference(indent, node, bytecode, receiver);
-        if (buf != null) {
-          return buf;
+        TextBuffer ref = KotlinWriter.stringifyReference(indent, node, bytecode, receiver);
+        if (ref != null) {
+          return ref;
         }
       }
 
       if (node.type == ClassesProcessor.ClassNode.Type.LOCAL && ktData.metadata instanceof KotlinMetadata.Class) {
         // Work around the Java-targeted anonymous class verification
         node.type = ClassesProcessor.ClassNode.Type.ANONYMOUS;
-        TextBuffer buf = new TextBuffer();
         buf.addBytecodeMapping(bytecode);
         new KotlinWriter().writeClass(node, buf, indent);
         return buf;
@@ -78,7 +81,6 @@ public class KNewExprent extends NewExprent implements KExprent {
           MethodDescriptor realDesc = MethodDescriptor.parseDescriptor(lambdaInfo.content_method_descriptor);
 
           MethodWrapper wrapper = node.getWrapper().getMethodWrapper(name, lambdaInfo.content_method_descriptor);
-          TextBuffer buf = new TextBuffer();
           buf.append("{ ");
 
           if (referencedDesc.params.length > 0) {
@@ -169,13 +171,71 @@ public class KNewExprent extends NewExprent implements KExprent {
         DecompilerContext.setProperty(DecompilerContext.CURRENT_METHOD_WRAPPER, outerWrapper);
       }
     } else if (isAnonymous()) {
-      TextBuffer buf = new TextBuffer();
       buf.addBytecodeMapping(bytecode);
       new KotlinWriter().writeClass(node, buf, indent);
       return buf;
     }
 
-    return super.toJava(indent);
+    if (getNewType().arrayDim == 0) {
+      if (!isEnumConst()) {
+        String typeName = KTypes.getKotlinType(getNewType());
+        
+        if (getConstructor() != null) {
+          TextBuffer enclosing = getQualifiedNewInstance(getNewType().value, getConstructor().getLstParameters(), indent);
+          if (enclosing != null) {
+            buf.append(enclosing).append('.');
+            ClassesProcessor.ClassNode newNode = DecompilerContext.getClassProcessor().getMapRootClasses().get(getNewType().value);
+            typeName = newNode != null ? newNode.simpleName : typeName.substring(typeName.lastIndexOf('.') + 1);
+          }
+        }
+
+        buf.appendTypeName(typeName, getNewType());
+      }
+      
+      if (getConstructor() != null) {
+        if (!isEnumConst() || getConstructor().getLstParameters().size() > 2) {
+          appendParameters(buf, getConstructor().getGenericArgs());
+          buf.append("(").append(getConstructor().appendParamList(indent)).append(')');
+        }
+      }
+    } else if (isVarArgParam()) {
+      boolean first = true;
+      for (Exprent element : getLstArrayElements()) {
+        if (!first) {
+          buf.append(",").appendPossibleNewline(" ");
+        }
+        buf.append(element.toJava(indent));
+        first = false;
+      }
+    } else {
+      buf.append(switch (getNewType().decreaseArrayDim().type) {
+        case BOOLEAN -> "booleanArrayOf";
+        case BYTE -> "byteArrayOf";
+        case SHORT -> "shortArrayOf";
+        case CHAR -> "charArrayOf";
+        case INT -> "intArrayOf";
+        case FLOAT -> "floatArrayOf";
+        case LONG -> "longArrayOf";
+        case DOUBLE -> "doubleArrayOf";
+        default -> "arrayOf";
+      });
+      buf.append('(');
+      buf.pushNewlineGroup(indent, 1);
+      buf.appendPossibleNewline();
+      boolean first = true;
+      for (Exprent element : getLstArrayElements()) {
+        if (!first) {
+          buf.append(",").appendPossibleNewline(" ");
+        }
+        buf.append(element.toJava(indent));
+        first = false;
+      }
+      buf.appendPossibleNewline("", true);
+      buf.popNewlineGroup();
+      buf.append(')');
+    }
+
+    return buf;
   }
 
   @Override

--- a/plugins/kotlin/testData/results/pkg/TestAnonymousEverything.dec
+++ b/plugins/kotlin/testData/results/pkg/TestAnonymousEverything.dec
@@ -83,7 +83,7 @@ public class TestAnonymousEverything {
    }// 72
 
    public fun testCapturedLocalVariables() {
-      val x: IntRef = new IntRef()// 75
+      val x: IntRef = IntRef()// 75
       x.element = 1
       { 
          `$x`.element++// 76
@@ -110,9 +110,9 @@ public class TestAnonymousEverything {
    public fun testThrows() {
       val lambda: Function1 = { x: Int ->// 105
          if (x < 0) {// 106
-            throw new IllegalArgumentException("x must be >= 0")// 107
+            throw IllegalArgumentException("x must be >= 0")// 107
          } else if (x == 2147483647) {
-            throw new IllegalArgumentException("x must not be Int.MAX_VALUE".toString())// 110
+            throw IllegalArgumentException("x must not be Int.MAX_VALUE".toString())// 110
          } else {
             x + 1// 112
          }

--- a/plugins/kotlin/testData/results/pkg/TestClassDec.dec
+++ b/plugins/kotlin/testData/results/pkg/TestClassDec.dec
@@ -6,9 +6,9 @@ public class TestClassDec {
    }
 
    public fun test() {
-      new TestClassDec.EmptyDec()
-      val vec: TestClassDec.Vec2iVal = new TestClassDec.Vec2iVal(1, 2)// 16
-      val vec1: TestClassDec.Vec2iVal = new TestClassDec.Vec2iVal(2, 4)// 17
+      TestClassDec.EmptyDec()
+      val vec: TestClassDec.Vec2iVal = TestClassDec.Vec2iVal(1, 2)// 16
+      val vec1: TestClassDec.Vec2iVal = TestClassDec.Vec2iVal(2, 4)// 17
       System.out.println(vec.getX())// 19
       System.out.println(this.dot(vec, vec1))// 20
    }// 21

--- a/plugins/kotlin/testData/results/pkg/TestCompileTimeErrors.dec
+++ b/plugins/kotlin/testData/results/pkg/TestCompileTimeErrors.dec
@@ -2,7 +2,7 @@ package pkg
 
 public class TestCompileTimeErrors {
    public fun <I, O> test(i: I): O where O : I, O : pkg.TestCompileTimeErrors.Test {
-      throw new NotImplementedError(null, 1, null)// 10
+      throw NotImplementedError(null, 1, null)// 10
    }
 
    public fun test2(i: Int?): pkg.TestCompileTimeErrors.Test? {

--- a/plugins/kotlin/testData/results/pkg/TestContracts.dec
+++ b/plugins/kotlin/testData/results/pkg/TestContracts.dec
@@ -11,7 +11,7 @@ public class TestContracts {
       }
 
       if (x == null) {// 13
-         throw new IllegalStateException("x is null".toString())
+         throw IllegalStateException("x is null".toString())
       } else {
          return x// 14
       }
@@ -33,7 +33,7 @@ public class TestContracts {
       }
 
       if (x !is Int) {// 31
-         throw new IllegalStateException("x is not Int".toString())
+         throw IllegalStateException("x is not Int".toString())
       } else {
          return (x as java.lang.Number).intValue()// 32
       }
@@ -60,7 +60,7 @@ public class TestContracts {
          callsInPlace(f)
       }
 
-      val var3: java.lang.Iterable = new IntRange(0, i) as java.lang.Iterable
+      val var3: java.lang.Iterable = IntRange(0, i) as java.lang.Iterable
       var var4: Int = 0
       val var5: java.util.Iterator = var3.iterator()
 

--- a/plugins/kotlin/testData/results/pkg/TestConvertedK2JOps.dec
+++ b/plugins/kotlin/testData/results/pkg/TestConvertedK2JOps.dec
@@ -1,10 +1,10 @@
 package pkg
 
 public class TestConvertedK2JOps {
-   public final val list: List<String> = CollectionsKt.listOf(new java.lang.String[]{"a", "b", "c"})// 4
-   public final val set: Set<String> = SetsKt.setOf(new java.lang.String[]{"a", "b", "c"})// 5
-   public final val map: Map<String, String> = MapsKt.mapOf(new Pair[]{TuplesKt.to("a", "b"), TuplesKt.to("c", "d")})// 6
-   public final val any: Any = new Object()
+   public final val list: List<String> = CollectionsKt.listOf(arrayOf("a", "b", "c"))// 4
+   public final val set: Set<String> = SetsKt.setOf(arrayOf("a", "b", "c"))// 5
+   public final val map: Map<String, String> = MapsKt.mapOf(arrayOf(TuplesKt.to("a", "b"), TuplesKt.to("c", "d")))// 6
+   public final val any: Any = Any()
 
    public fun codeConstructs() {
       System.out.println("Hello, world!")// 10

--- a/plugins/kotlin/testData/results/pkg/TestDataClass.dec
+++ b/plugins/kotlin/testData/results/pkg/TestDataClass.dec
@@ -35,7 +35,7 @@ public data class TestDataClass(dataClassVal: Regex, variableWithVeryLongName: I
       requestLineWrapsIfTheParamListIsTooLong: List<String> = this.requestLineWrapsIfTheParamListIsTooLong,
       nullability: String? = this.nullability
    ): TestDataClass {
-      return new TestDataClass(dataClassVal, variableWithVeryLongName, requestLineWrapsIfTheParamListIsTooLong, nullability)
+      return TestDataClass(dataClassVal, variableWithVeryLongName, requestLineWrapsIfTheParamListIsTooLong, nullability)
    }
 
    public open fun toString(): String {

--- a/plugins/kotlin/testData/results/pkg/TestDestructors.dec
+++ b/plugins/kotlin/testData/results/pkg/TestDestructors.dec
@@ -26,7 +26,7 @@ public class TestDestructors {
    public fun destructorImpossible(x: Pair<String, Nothing>): String {
       val a: java.lang.String = x.component1() as java.lang.String// 38
       x.component2()
-      throw new KotlinNothingValueException()
+      throw KotlinNothingValueException()
    }
 
    public fun destructExtensionFunction(x: Int) {

--- a/plugins/kotlin/testData/results/pkg/TestEnumClass.dec
+++ b/plugins/kotlin/testData/results/pkg/TestEnumClass.dec
@@ -26,7 +26,7 @@ public enum class TestEnumClass(number: Int = 4) {
    @JvmStatic
    @JvmSynthetic
    fun `$values`(): Array<TestEnumClass> {
-      new TestEnumClass[]{A, B, C, D}
+      arrayOf(A, B, C, D)
    }
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestForRange.dec
+++ b/plugins/kotlin/testData/results/pkg/TestForRange.dec
@@ -32,7 +32,7 @@ public class TestForRange {
 
    public fun testIntStepX(x: Int) {
       if (x <= 0) {
-         throw new IllegalArgumentException("Step must be positive, was: $x.")
+         throw IllegalArgumentException("Step must be positive, was: $x.")
       } else {
          var i: Int = 1
          val var3: Int = ProgressionUtilKt.getProgressionLastElement(1, 100, x)
@@ -72,7 +72,7 @@ public class TestForRange {
 
    public fun testIntDownToStepX(x: Int) {
       if (x <= 0) {
-         throw new IllegalArgumentException("Step must be positive, was: $x.")
+         throw IllegalArgumentException("Step must be positive, was: $x.")
       } else {
          val var2: Int = -x
          var i: Int = 100
@@ -161,7 +161,7 @@ public class TestForRange {
 
    public fun testIntYStepX(x: Int, y: Int, z: Int) {
       if (z <= 0) {
-         throw new IllegalArgumentException("Step must be positive, was: $z.")
+         throw IllegalArgumentException("Step must be positive, was: $z.")
       } else {
          var i: Int = x
          val var5: Int = ProgressionUtilKt.getProgressionLastElement(x, y, z)

--- a/plugins/kotlin/testData/results/pkg/TestIfRange.dec
+++ b/plugins/kotlin/testData/results/pkg/TestIfRange.dec
@@ -20,13 +20,13 @@ public class TestIfRange {
    }// 20
 
    public fun testIntStep(x: Int) {
-      if (CollectionsKt.contains(RangesKt.step(new IntRange(1, 100) as IntProgression, 2) as java.lang.Iterable, x)) {// 23
+      if (CollectionsKt.contains(RangesKt.step(IntRange(1, 100) as IntProgression, 2) as java.lang.Iterable, x)) {// 23
          System.out.println(x)// 24
       }
    }// 26
 
    public fun testIntStepY(x: Int, y: Int) {
-      if (CollectionsKt.contains(RangesKt.step(new IntRange(1, 100) as IntProgression, y) as java.lang.Iterable, x)) {// 28
+      if (CollectionsKt.contains(RangesKt.step(IntRange(1, 100) as IntProgression, y) as java.lang.Iterable, x)) {// 28
          System.out.println(x)// 29
       }
    }// 31

--- a/plugins/kotlin/testData/results/pkg/TestKotlinTypes.dec
+++ b/plugins/kotlin/testData/results/pkg/TestKotlinTypes.dec
@@ -6,7 +6,7 @@ public class TestKotlinTypes {
    }
 
    public fun throwAlways(): Nothing {
-      throw new Exception()// 5
+      throw Exception()// 5
    }
 }
 

--- a/plugins/kotlin/testData/results/pkg/TestNonInlineLambda.dec
+++ b/plugins/kotlin/testData/results/pkg/TestNonInlineLambda.dec
@@ -48,7 +48,7 @@ public open class TestNonInlineLambda {
    }// 34
 
    public fun testCaptureMutableInt(x: Int) {
-      val y: IntRef = new IntRef()// 37
+      val y: IntRef = IntRef()// 37
       y.element = x
       this.execute({ // 38
          System.out.println(`$y`.element)// 39
@@ -77,7 +77,7 @@ public open class TestNonInlineLambda {
    }// 57
 
    public fun testCaptureMutableObject(x: String) {
-      val y: ObjectRef = new ObjectRef()// 60
+      val y: ObjectRef = ObjectRef()// 60
       y.element = x
       this.execute({ // 61
          System.out.println(`$y`.element)// 62
@@ -106,7 +106,7 @@ public open class TestNonInlineLambda {
    }// 80
 
    public fun testCaptureAndMutateInt(x: Int) {
-      val y: IntRef = new IntRef()// 83
+      val y: IntRef = IntRef()// 83
       this.execute({ // 84
          while (`$y`.element < 10) {// 85
             System.out.println(`$y`.element++)// 86
@@ -127,7 +127,7 @@ public open class TestNonInlineLambda {
    }// 95
 
    public fun testCaptureAndMutateString(x: String) {
-      val y: ObjectRef = new ObjectRef()// 98
+      val y: ObjectRef = ObjectRef()// 98
       y.element = ""
       this.execute({ // 99
          while ((`$y`.element as java.lang.String).length() < 10) {// 100

--- a/plugins/kotlin/testData/results/pkg/TestNothingReturns.dec
+++ b/plugins/kotlin/testData/results/pkg/TestNothingReturns.dec
@@ -9,18 +9,18 @@ public class TestNothingReturns {
 
    public fun test1(): Nothing {
       this.loop()// 11
-      throw new KotlinNothingValueException()
+      throw KotlinNothingValueException()
    }
 
    public fun test2(): Long {
       this.test1()// 15
-      throw new KotlinNothingValueException()
+      throw KotlinNothingValueException()
    }
 
    public fun test3(i: Int): Int {
       if (i == 0) {// 19
          this.loop()// 20
-         throw new KotlinNothingValueException()
+         throw KotlinNothingValueException()
       } else {
          return this.test3(i - 1) + 1// 23
       }
@@ -28,19 +28,19 @@ public class TestNothingReturns {
 
    public fun test4() {
       this.loop()// 27
-      throw new KotlinNothingValueException()
+      throw KotlinNothingValueException()
    }
 
    public fun test5(s: String): String {
       StringsKt.repeat(s as java.lang.CharSequence, 5)// 32
       this.loop()
-      throw new KotlinNothingValueException()
+      throw KotlinNothingValueException()
    }
 
    public fun test6(s: String?): String {
       if (s == null) {// 36
          this.loop()
-         throw new KotlinNothingValueException()
+         throw KotlinNothingValueException()
       } else {
          return s
       }

--- a/plugins/kotlin/testData/results/pkg/TestNullableOperator.dec
+++ b/plugins/kotlin/testData/results/pkg/TestNullableOperator.dec
@@ -36,7 +36,7 @@ public class TestNullableOperator {
       if (x != null) {// 21
          return x
       } else {
-         throw new Exception()
+         throw Exception()
       }
    }
 
@@ -50,7 +50,7 @@ public class TestNullableOperator {
       if (x != null) {// 29
          x.printStackTrace()
       } else {
-         throw new Exception()
+         throw Exception()
       }
    }
 

--- a/plugins/kotlin/testData/results/pkg/TestObject.dec
+++ b/plugins/kotlin/testData/results/pkg/TestObject.dec
@@ -2,7 +2,7 @@ package pkg
 
 public object TestObject {
    private final var objectVar: Int = 42// 8
-   public final val objectVal: Regex = new Regex("")// 10
+   public final val objectVal: Regex = Regex("")// 10
    public const val objectConstVal: Int = 926
 
    public fun objectFun() {

--- a/plugins/kotlin/testData/results/pkg/TestPoorNames.dec
+++ b/plugins/kotlin/testData/results/pkg/TestPoorNames.dec
@@ -17,7 +17,7 @@ public class TestPoorNames {
    }// 17
 
    public fun test() {
-      new TestPoorNames.Class with spaces()
+      TestPoorNames.Class with spaces()
       this.Dangerous_function_name__/* $VF was: Dangerous function name?! */()// 23
       this.functionWithParameters(42, "test")// 24
    }// 25

--- a/plugins/kotlin/testData/results/pkg/TestReflection.dec
+++ b/plugins/kotlin/testData/results/pkg/TestReflection.dec
@@ -25,7 +25,7 @@ public class TestReflection {
    public fun testFunctionReference() {
       val f: KFunction = TestReflection::testClassReference as KFunction// 23
       System.out.println(TestReflection::testClassReference as KFunction)// 24
-      (f as Function1)(new TestReflection())// 25
+      (f as Function1)(TestReflection())// 25
    }// 26
 
    public fun testThis() {

--- a/plugins/kotlin/testData/results/pkg/TestTopLevelKt.dec
+++ b/plugins/kotlin/testData/results/pkg/TestTopLevelKt.dec
@@ -3,7 +3,7 @@ package pkg
 public final var topLevelVar: Int = 42// 7
    internal set
 
-public final val topLevelVal: Regex = new Regex("")// 9
+public final val topLevelVal: Regex = Regex("")// 9
 public const val topLevelConstVal: Int = 926
 
 public fun topLevelFun() {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
@@ -43,6 +43,7 @@ public class NewExprent extends Exprent {
   private boolean anonymous;
   private boolean lambda;
   private boolean methodReference = false;
+
   private boolean enumConst;
   private List<VarType> genericArgs = new ArrayList<>();
   private VarType inferredLambdaType = null;
@@ -534,7 +535,7 @@ public class NewExprent extends Exprent {
     return node != null && node.type == ClassNode.Type.ANONYMOUS;
   }
 
-  private static TextBuffer getQualifiedNewInstance(String classname, List<Exprent> lstParams, int indent) {
+  public static TextBuffer getQualifiedNewInstance(String classname, List<Exprent> lstParams, int indent) {
     ClassNode node = DecompilerContext.getClassProcessor().getMapRootClasses().get(classname);
 
     if (node != null && node.type != ClassNode.Type.ROOT && node.type != ClassNode.Type.LOCAL
@@ -841,6 +842,10 @@ public class NewExprent extends Exprent {
 
   public void setAnonymous(boolean anonymous) {
     this.anonymous = anonymous;
+  }
+
+  public boolean isEnumConst() {
+    return enumConst;
   }
 
   public void setEnumConst(boolean enumConst) {


### PR DESCRIPTION
**Modifies [`NewExprent`](https://github.com/Vineflower/vineflower/blob/77353d83c3501b88b9831f0368794fbda8f0311e/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java)**: to publicize a method

Most visibly removes `new` from constructor calls, but also converts arrays to actually being `arrayOf` and similar