### PR TITLE
Add Automatic-Module-Name to the manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,7 +189,8 @@ jar {
     attributes (
       'Main-Class': 'org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler',
       'Implementation-Name': "Vineflower",
-      'Implementation-Version': project.version
+      'Implementation-Version': project.version,
+      'Automatic-Module-Name': "org.vineflower.vineflower"
     )
   }
 }
@@ -228,7 +229,8 @@ def allJar = tasks.register('allJar', Jar) {allJar ->
     attributes (
       'Main-Class': 'org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler',
       'Implementation-Name': "Vineflower",
-      'Implementation-Version': project.version
+      'Implementation-Version': project.version,
+      'Automatic-Module-Name': "org.vineflower.vineflower"
     )
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ jar {
       'Main-Class': 'org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler',
       'Implementation-Name': "Vineflower",
       'Implementation-Version': project.version,
-      'Automatic-Module-Name': "org.vineflower.vineflower"
+      'Automatic-Module-Name': "org.jetbrains.java.decompiler"
     )
   }
 }
@@ -230,7 +230,7 @@ def allJar = tasks.register('allJar', Jar) {allJar ->
       'Main-Class': 'org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler',
       'Implementation-Name': "Vineflower",
       'Implementation-Version': project.version,
-      'Automatic-Module-Name': "org.vineflower.vineflower"
+      'Automatic-Module-Name': "org.jetbrains.java.decompiler"
     )
   }
 


### PR DESCRIPTION
Gives VF an automatic module name of `org.jetbrains.java.decompiler`, so it can be used in modular projects without gymnastics.

I've manually tested that:
- The jar is still not modular when run standalone from CLI
- The module is named correctly at runtime in a modular context
- The plugins built into the all-jar are still able to be loaded in a modular context

Resolves #121